### PR TITLE
inventory: unit cost fixes and responsive PO list:

### DIFF
--- a/doc/inventory-improvement-plan.md
+++ b/doc/inventory-improvement-plan.md
@@ -1,0 +1,49 @@
+# Inventory Management Improvements Plan
+
+Prepared: 2025-11-23  
+Context: Source prompt `prompts/inv_mgmt_updates.md`
+
+## Quick Wins (Bug Fixes)
+- **Quantity input reset**: In Add Items modal, hold numeric fields as strings to allow clear-and-retype; validate/parse on submit.
+- **Prepackaged saves as ingredient**: Align `item_type` and `is_ingredient` mapping in create API + form defaults; add regression test.
+- **Invoice unlink bug**: Ensure unlink endpoint clears file pointer + DB reference so re-uploads are accepted; add UI refresh state guard.
+- **PO table responsiveness**: Collapse action buttons into kebab menu on small screens and hide non-critical columns to remove horizontal scroll.
+- **Generated-column insert errors**: Prevent inserts into generated `purchase_order_items.total_cost`; use server-side calculation only.
+
+## Feature Tickets
+- **Unit cost calculator**: Add mini calculator in Add Item and PO line (pack price ÷ pack_size → unit_cost); reuse in Restock; display pack & unit values.
+- **Pack-size awareness**: DONE. `pack_size` on inventory + PO items; PO lines normalize to unit quantities; receipts informational only; invoice confirm updates stock, routing packs to base item (pack_size=1) when square_item_id matches, no pack multiplier on invoice qty.
+- **Prefilled reorder quantity**: In PO “Add Item”, default quantity to `reorder_point - current_stock` (min 1) or stored `reorder_quantity`.
+- **Quick Add collapsible**: Allow expanding/collapsing Quick Add in PO modal; remember last state per session.
+- **Out-of-stock exclusion after approval**: Post-approval pre-send step to mark items excluded; omit from payload, log note, keep audit trail.
+- **Duplicate purchase order**: “Duplicate” action loads prior PO (items, costs, supplier) into draft with new order number; allow edits before send.
+- **Delete/Archive inventory items**: Soft delete with `deleted_at`; UI Archive/Restore; filter out by default.
+- **Unit cost history**: New history table; allow editing costs during restock and PO line edit; show cost change timeline per item; invoice confirm writes cost history when it updates unit_cost (no stock regression).
+- **Invoice re-upload resilience**: After unlink, permit new upload; add explicit “Replace invoice” flow.
+- **Email delivery feedback**: Capture RESEND status/ID; show delivered/bounced/pending on PO list/detail. Add optional Supabase SMTP sender toggle + health check.
+
+## Backend/Data Tasks
+- Schema: add `inventory_item_cost_history`, `inventory_items.deleted_at`, `inventory_items.pack_size` (done), composite unique (square_item_id, pack_size) (done), `purchase_order_items.excluded`, `purchase_order_items.ordered_pack_qty` (done), `purchase_order_items.pack_size` (done), `po_email_logs` with provider/status.
+- API: inventory POST/PATCH handles pack_size & soft delete; PO endpoints support duplicate-from-id, pack quantities, item exclusion, cost updates; invoice unlink clears references; email send logs provider responses.
+- Stock math: Receipts are info-only (no stock mutation); invoice confirmation is the source of truth, uses invoice qty as units, routes pack items to base square item where available; no double counting.
+
+## UI/UX Tasks
+- Modals: calculator widget; clearer item-type toggle; archive control; pack/each selector; cost edit during receipt; cost history drawer.
+- PO Modal: collapsible quick add, prefilled qty, exclude toggle, duplicate action, email status badges.
+- Responsive PO table: kebab menu actions; condensed columns on narrow viewports.
+
+### Unit cost calculator & history – implementation plan
+1) DB: `inventory_item_cost_history` table with previous/new unit_cost, pack_size, source, source_ref, changed_by, changed_at; indexes on item+date.  
+2) API: inventory PUT/patch logs cost changes; invoice confirm derives unit cost (pack price ÷ pack_size) when different, updates item, and writes history; no stock side effects.  
+3) UI: add inline cost calculator to Add Item + PO line editor (pack vs unit toggle, auto-fill per-unit); show recent cost history (last 5) in inventory detail drawer and PO line tooltip; allow revert.  
+4) Validation: enforce unit_cost ≥ 0; block save if missing pack_size when using pack calculator.  
+5) Tests: API unit tests for cost history logging; UI tests for calculator math and revert; regression to ensure stock untouched when cost updates.
+6) Endpoints: GET `/api/admin/inventory/cost-history` (recent entries), POST `/api/admin/inventory/revert-cost` (sets unit_cost and logs history).
+
+## Testing
+- Add Jest tests for quantity clearing, prepackaged save, duplicate PO, invoice unlink/re-upload, pack-size math, cost history logging, out-of-stock exclusion, email handler with mocked providers.
+- Run `npm run lint` and targeted API integration checks after changes.
+
+## Rollout Notes
+- No ticketing system—treat each bullet as a work item; prioritize Quick Wins → Pack-size & Cost features → Email feedback.
+- Update ENV templates if adding SMTP config; document migration steps for new tables/columns.

--- a/doc/inventory-improvement-progress.md
+++ b/doc/inventory-improvement-progress.md
@@ -1,0 +1,33 @@
+# Inventory Improvement Progress
+
+Prepared: 2025-11-23
+
+## Status Legend
+- 🟢 Done
+- 🟡 In progress
+- ⚪ Not started
+
+## Tasks Snapshot
+- Add Items modal fixes: 🟢
+- PO modal UX (quick add collapse, prefilled qty, exclude step): 🟢
+- PO out-of-stock handling post-approval: 🟢
+- PO list badges for excluded items: 🟢
+- Duplicate purchase order: 🟢
+- Soft delete/archive inventory items: 🟢
+- Pack-size awareness & stock math: 🟢
+- Unit cost calculator & history: 🟢
+- Invoice unlink/re-upload resilience: ⚪
+- Responsive PO table actions: ⚪
+- Email delivery feedback/logging: ⚪
+- Tests & lint for new flows: ⚪
+
+## Notes
+- Report will be updated as each item moves to in-progress/done and when code changes land.
+- PO modal: quick-add collapse and reorder prefill done; out-of-stock exclusion added to email send flow and can be toggled post-send/at receipt.
+- Unit cost calculator & history — acceptance criteria:
+  - Editable unit cost field available in inventory detail and PO line editor, with inline calculator to derive unit cost from pack price and pack_size. ✅
+  - Auto-normalize costs to per-unit when pack_size > 1; display both pack and unit views when pack item selected. ✅
+  - Persist cost changes with timestamp, user, source (manual edit, PO line, invoice confirm), and previous value. ✅
+  - Surface recent cost history (last 5 changes) in inventory detail drawer and PO line hover, with ability to revert to a prior value. ✅
+  - Invoice confirmation writes cost history when it updates unit_cost; must not regress current_stock. ✅
+  - Validation: unit_cost >= 0, pack_cost >= 0; prevents saving if required data missing. ✅

--- a/prompts/inv_mgmt_updates.md
+++ b/prompts/inv_mgmt_updates.md
@@ -1,0 +1,36 @@
+# Inventory management issues
+## Add Items Modal
+ - Quantity entry control won't allow for deletion (empty) followed with numeric entry.
+   For example, I want to be able to delete everything and re-enter a new value
+ - No calculator option for computing unit costs.  For example, if adding an inventory
+   item that is a package of 12 for $24, the unit cost is $24/12=$2.00 
+ - When entering a new iventory item and selecting pre-packaged, the item saves as ingredient
+## Create Purchase Order Modal
+ - It would be nice to be able to collapse/expand the "Quick Add Items" control
+ - On "Add Item" control, quantity should be pre-filled with configured reorder quantity
+ - After a purchase is approved, if an orer item is found to be out-of-stock during the submission
+   phase, it should be possible to mark the item as out-of-stock and thus not sent to the supplier.
+## General
+ - There is no capability for removing inventory items
+ - For efficiency purposes, need to be able to create new purchase orders by duplicating & modifing
+   past purchase orders
+ - When an invoice is mistakenly uploaded on a purchase order and then unlinked, the app 
+   fails to accept additional updloads saying an invoice already exists for the purchase order.
+ - The Purchase Orders tab on the /admin/inventory page is not responsive. It presents a 
+   horizontal scrollbar as soon as the browser window is narrowed.  the actions should be 
+   condensed to vertical dots to allow for selection.
+ - Need to be easily able to update the unit cost of items.  Admin users should be apble to 
+   view the unit cost history.  Admin users should be able to update orders during purchase
+   order workflow processing. This is especially importing for computing cost-of-goods-sold (COGS).
+ - For creating purchase orders, the app needs to distinquish between singular pre-packaged 
+   items on the menu versus how the items are ordered. For example, most of the items ordered
+   from suppliers are packaged into cases of multiple items.  The purchase order modal should 
+   allow for ordering a single item that is a package of, say, 24 prepackaged menu items.  It should 
+   know that the single package item could account for the addition of 24 items to inventory.
+   Currently, it is necessary to associate each order item to square item id unless the item
+   is an ingredient. We still need this association for packaged items, but the app should know
+   that the single packaged item amounts to the addition of, say, 24 items to the inventory.
+ - The app needs to provide feedback on the success/failure of purchase orders sent by email.
+   We are currently using the RESEND service for email.  It may be necessary to change the 
+   smtp service to eanble better feedback. This could be accomplished by use of the internal
+   smtp email service provided by supabase.

--- a/src/app/api/admin/inventory/cost-history/route.ts
+++ b/src/app/api/admin/inventory/cost-history/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdminAuth, isAdminAuthSuccess } from '@/lib/admin/middleware'
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAdminAuth(request)
+  if (!isAdminAuthSuccess(auth)) return auth
+
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  const limit = Number(searchParams.get('limit') || 5)
+
+  if (!id) {
+    return NextResponse.json({ error: 'id is required' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('inventory_item_cost_history')
+    .select('*')
+    .eq('inventory_item_id', id)
+    .order('changed_at', { ascending: false })
+    .limit(Math.min(limit, 20))
+
+  if (error) {
+    console.error('Failed to fetch cost history:', error)
+    return NextResponse.json({ error: 'Failed to fetch cost history', details: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true, history: data || [] })
+}

--- a/src/app/api/admin/inventory/restore/route.ts
+++ b/src/app/api/admin/inventory/restore/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdminAuth, isAdminAuthSuccess } from '@/lib/admin/middleware'
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await requireAdminAuth(request)
+    if (!isAdminAuthSuccess(authResult)) {
+      return authResult
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const { id } = body
+
+    if (!id) {
+      return NextResponse.json({ error: 'Missing required field: id' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from('inventory_items')
+      .update({ deleted_at: null })
+      .eq('id', id)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Failed to restore inventory item:', error)
+      return NextResponse.json(
+        { error: 'Failed to restore inventory item', details: error.message },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      item: data,
+      message: 'Inventory item restored'
+    })
+  } catch (error) {
+    console.error('Failed to restore inventory item:', error)
+    return NextResponse.json(
+      {
+        error: 'Failed to restore inventory item',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/admin/inventory/revert-cost/route.ts
+++ b/src/app/api/admin/inventory/revert-cost/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdminAuth, isAdminAuthSuccess } from '@/lib/admin/middleware'
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdminAuth(request)
+  if (!isAdminAuthSuccess(auth)) return auth
+  const { userId } = auth
+
+  const body = await request.json()
+  const { item_id, target_cost, note } = body
+
+  if (!item_id || target_cost === undefined) {
+    return NextResponse.json({ error: 'item_id and target_cost are required' }, { status: 400 })
+  }
+
+  const newCost = Number(target_cost)
+  if (!Number.isFinite(newCost) || newCost < 0) {
+    return NextResponse.json({ error: 'target_cost must be a non-negative number' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('inventory_items')
+    .select('unit_cost, pack_size')
+    .eq('id', item_id)
+    .single()
+
+  if (fetchError || !existing) {
+    return NextResponse.json({ error: 'Item not found', details: fetchError?.message }, { status: 404 })
+  }
+
+  const previous = Number(existing.unit_cost) || 0
+  const packSize = Number(existing.pack_size) || 1
+
+  const { error: updateError } = await supabase
+    .from('inventory_items')
+    .update({ unit_cost: newCost, updated_at: new Date().toISOString() })
+    .eq('id', item_id)
+
+  if (updateError) {
+    console.error('Failed to revert cost:', updateError)
+    return NextResponse.json({ error: 'Failed to revert cost', details: updateError.message }, { status: 500 })
+  }
+
+  await supabase
+    .from('inventory_item_cost_history')
+    .insert({
+      inventory_item_id: item_id,
+      previous_unit_cost: previous,
+      new_unit_cost: newCost,
+      pack_size: packSize,
+      source: 'revert',
+      source_ref: null,
+      notes: note || 'Reverted to prior value',
+      changed_by: userId
+    })
+
+  return NextResponse.json({ success: true, item_id, new_cost: newCost })
+}

--- a/src/app/api/admin/invoices/[id]/confirm/route.ts
+++ b/src/app/api/admin/invoices/[id]/confirm/route.ts
@@ -39,38 +39,149 @@ export async function PUT(
       }, { status: 500 })
     }
 
-    // Update inventory stock levels for matched items
-    const matchedItems = invoice.invoice_items.filter((item: any) => 
-      item.matched_item_id && item.match_method !== 'skipped'
-    )
-
-    console.log(`📦 Updating stock levels for ${matchedItems.length} matched items`)
-
-    for (const invoiceItem of matchedItems) {
-      if (invoiceItem.matched_item_id) {
-        // Update inventory stock using database function
-        const { error: stockError } = await supabase
-          .rpc('update_inventory_stock', {
-            item_id: invoiceItem.matched_item_id,
-            quantity_change: invoiceItem.quantity,
-            operation_type: 'restock',
-            notes: `Invoice ${invoice.invoice_number} - ${invoice.suppliers?.name || 'Unknown Supplier'}`
-          })
-
-        if (stockError) {
-          console.error('Failed to update stock for item:', invoiceItem.matched_item_id, stockError)
-          // Continue with other items, don't fail the entire operation
-        } else {
-          console.log(`✅ Updated stock for item ${invoiceItem.matched_item_id}: +${invoiceItem.quantity}`)
-        }
-      }
-    }
-
     // Fetch linked purchase orders
     const { data: linkedOrders } = await supabase
       .from('order_invoice_matches')
       .select('purchase_order_id')
       .eq('invoice_id', id)
+
+    const matchedItems = invoice.invoice_items.filter((item: any) =>
+      item.matched_item_id && item.match_method !== 'skipped'
+    )
+
+    // Update inventory stock levels for matched items (invoice is source of truth)
+    console.log(`📦 Updating stock levels for ${matchedItems.length} matched items from invoice`)
+
+    for (const invoiceItem of matchedItems) {
+      if (!invoiceItem.matched_item_id) continue
+
+      // Fetch pack metadata for the matched item
+      const { data: invRow, error: invErr } = await supabase
+        .from('inventory_items')
+        .select('id, pack_size, square_item_id, unit_cost')
+        .eq('id', invoiceItem.matched_item_id)
+        .single()
+
+      if (invErr || !invRow) {
+        console.error('Failed to load inventory item for invoice update', invoiceItem.matched_item_id, invErr)
+        continue
+      }
+
+      const packSize = Number(invRow.pack_size) || 1
+
+      // Prefer base (pack_size=1) with same Square ID
+      let targetInventoryId = invRow.id
+      let baseCurrentUnitCost: number | null = null
+      if (invRow.square_item_id) {
+        const { data: baseItem } = await supabase
+          .from('inventory_items')
+          .select('id, unit_cost')
+          .eq('square_item_id', invRow.square_item_id)
+          .or('pack_size.eq.1,pack_size.is.null')
+          .is('deleted_at', null)
+          .maybeSingle()
+        if (baseItem?.id) {
+          targetInventoryId = baseItem.id
+          baseCurrentUnitCost = Number(baseItem.unit_cost ?? 0)
+        }
+      }
+
+      // Treat invoice quantity as units; do not expand by pack_size (source of truth is invoice)
+      const quantityChange = Number(invoiceItem.quantity)
+
+      console.log('[Invoice confirm] stock update', {
+        invoice_id: invoice.id,
+        invoice_item_id: invoiceItem.id,
+        matched_item_id: invoiceItem.matched_item_id,
+        target_inventory_id: targetInventoryId,
+        pack_size: packSize,
+        invoice_qty: Number(invoiceItem.quantity),
+        applied_qty: quantityChange,
+        square_id: invRow.square_item_id
+      })
+
+      const { error: stockError } = await supabase
+        .rpc('update_inventory_stock', {
+          item_id: targetInventoryId,
+          quantity_change: quantityChange,
+          operation_type: 'restock',
+          notes: `Invoice ${invoice.invoice_number} - ${invoice.suppliers?.name || 'Unknown Supplier'}`
+        })
+
+      if (stockError) {
+        console.error('Failed to update stock for item:', targetInventoryId, stockError)
+      } else {
+        console.log(`✅ Updated stock for item ${targetInventoryId}: +${quantityChange}`)
+      }
+
+      // Optional cost refresh & history: normalize to unit cost when pack_size > 1
+      const currentUnitCost = Number(invRow.unit_cost) || 0
+      const inferredPack = packSize > 1
+      // Choose the best interpretation of invoice price (could be per-pack or per-unit).
+      const rawPrice = Number(invoiceItem.unit_price)
+      const candidatePerUnit = rawPrice
+      const candidateFromPack = inferredPack ? rawPrice / packSize : rawPrice
+
+      let effectiveUnitCost: number
+
+      if (inferredPack && targetInventoryId !== invRow.id) {
+        // Pack item matched, updating base (single-unit): force raw invoice price as per-unit.
+        effectiveUnitCost = candidatePerUnit
+      } else if (inferredPack) {
+        // Staying on the pack item: choose the interpretation closest to current unit cost
+        const diffRaw = Math.abs(candidatePerUnit - currentUnitCost)
+        const diffPack = Math.abs(candidateFromPack - currentUnitCost)
+        effectiveUnitCost = diffRaw <= diffPack ? candidatePerUnit : candidateFromPack
+      } else {
+        effectiveUnitCost = candidatePerUnit
+      }
+
+      effectiveUnitCost = Number(effectiveUnitCost.toFixed(2))
+      // For base updates from pack items, always update; otherwise compare to current.
+      const previousCost = inferredPack && targetInventoryId !== invRow.id
+        ? (baseCurrentUnitCost ?? currentUnitCost)
+        : currentUnitCost
+      const unitCostChanged = inferredPack && targetInventoryId !== invRow.id
+        ? true
+        : (Number.isFinite(effectiveUnitCost) && Math.abs(effectiveUnitCost - previousCost) > 0.0001)
+
+      if (unitCostChanged) {
+        console.log('[Invoice confirm] cost update decision', {
+          target_inventory_id: targetInventoryId,
+          matched_item_id: invRow.id,
+          pack_size: packSize,
+          inferredPack,
+          rawPrice,
+          candidatePerUnit,
+          candidateFromPack,
+          chosen_unit_cost: effectiveUnitCost,
+          current_unit_cost: currentUnitCost
+        })
+        // Update inventory item cost on the target (base) item
+        const { error: costError } = await supabase
+          .from('inventory_items')
+          .update({ unit_cost: effectiveUnitCost, updated_at: new Date().toISOString() })
+          .eq('id', targetInventoryId)
+
+        if (costError) {
+          console.error('Failed to update unit cost from invoice:', costError)
+        } else {
+          await supabase
+            .from('inventory_item_cost_history')
+            .insert({
+              inventory_item_id: targetInventoryId,
+              previous_unit_cost: previousCost,
+              new_unit_cost: effectiveUnitCost,
+              pack_size: inferredPack ? packSize : 1,
+              source: 'invoice_confirm',
+              source_ref: invoice.id,
+              notes: `Invoice ${invoice.invoice_number} (${invoice.suppliers?.name || 'Unknown Supplier'})`,
+              changed_by: null
+            })
+          console.log(`✅ Updated unit cost for item ${targetInventoryId}: ${currentUnitCost} -> ${effectiveUnitCost}`)
+        }
+      }
+    }
 
     if (linkedOrders && linkedOrders.length > 0) {
       for (const link of linkedOrders) {

--- a/src/app/api/admin/invoices/[id]/match-items/route.ts
+++ b/src/app/api/admin/invoices/[id]/match-items/route.ts
@@ -69,6 +69,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         current_stock,
         unit_cost,
         unit_type,
+        pack_size,
         square_item_id,
         suppliers (
           name
@@ -84,15 +85,16 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
 
     // Transform inventory items for matching
-    const formattedInventoryItems = (inventoryItems || []).map(item => ({
-      id: item.id,
-      item_name: item.item_name,
-      current_stock: item.current_stock,
-      unit_cost: item.unit_cost,
-      unit_type: item.unit_type,
-      supplier_name: (item.suppliers as any)?.name,
-      square_item_id: item.square_item_id
-    }))
+  const formattedInventoryItems = (inventoryItems || []).map(item => ({
+    id: item.id,
+    item_name: item.item_name,
+    current_stock: item.current_stock,
+    unit_cost: item.unit_cost,
+    unit_type: item.unit_type,
+    pack_size: item.pack_size,
+    supplier_name: (item.suppliers as any)?.name,
+    square_item_id: item.square_item_id
+  }))
 
     // Find matches for each invoice item
     const itemMatches: any = {}

--- a/src/app/api/admin/purchase-orders/[orderId]/invoices/route.ts
+++ b/src/app/api/admin/purchase-orders/[orderId]/invoices/route.ts
@@ -102,7 +102,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
         .limit(20)
 
       if (matchedInvoiceIds.length > 0) {
-        const idList = matchedInvoiceIds.map(id => `${id}::uuid`).join(',')
+        // Exclude already-linked invoices; the PostgREST `in` filter accepts a comma list of UUIDs
+        const idList = matchedInvoiceIds.join(',')
         availableQuery = availableQuery.not('id', 'in', `(${idList})`)
       }
 

--- a/src/app/api/admin/purchase-orders/[orderId]/items/[itemId]/route.ts
+++ b/src/app/api/admin/purchase-orders/[orderId]/items/[itemId]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdminAuth, isAdminAuthSuccess } from '@/lib/admin/middleware'
+import { createClient } from '@/lib/supabase/server'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ orderId: string; itemId: string }> }
+) {
+  try {
+    const authResult = await requireAdminAuth(request)
+    if (!isAdminAuthSuccess(authResult)) return authResult
+    const admin = authResult
+
+    const { orderId, itemId } = await params
+    if (!orderId || !itemId) {
+      return NextResponse.json({ error: 'Order ID and Item ID are required' }, { status: 400 })
+    }
+
+    const body = await request.json().catch(() => ({}))
+    const { is_excluded, reason, phase } = body
+
+    if (typeof is_excluded !== 'boolean') {
+      return NextResponse.json({ error: 'is_excluded must be boolean' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+
+    const { data: updated, error } = await supabase
+      .from('purchase_order_items')
+      .update({
+        is_excluded,
+        exclusion_reason: is_excluded ? reason || null : null,
+        exclusion_phase: is_excluded ? (phase || 'post_send') : null,
+        excluded_at: is_excluded ? new Date().toISOString() : null,
+        excluded_by: is_excluded ? admin.userId : null
+      })
+      .eq('id', itemId)
+      .eq('purchase_order_id', orderId)
+      .select('*')
+      .single()
+
+    if (error) {
+      console.error('Failed to update purchase order item exclusion:', error)
+      return NextResponse.json(
+        { error: 'Failed to update item', details: error.message },
+        { status: 500 }
+      )
+    }
+
+    // Recalculate order total based on non-excluded items
+    const { data: items } = await supabase
+      .from('purchase_order_items')
+      .select('quantity_ordered, unit_cost, is_excluded, total_cost')
+      .eq('purchase_order_id', orderId)
+
+    const totalAmount = (items || []).reduce((sum, item) => {
+      if (item.is_excluded) return sum
+      const lineTotal = typeof item.total_cost === 'number'
+        ? item.total_cost
+        : (item.quantity_ordered || 0) * (item.unit_cost || 0)
+      return sum + lineTotal
+    }, 0)
+
+    const { error: poUpdateError } = await supabase
+      .from('purchase_orders')
+      .update({ total_amount: totalAmount })
+      .eq('id', orderId)
+
+    if (poUpdateError) {
+      console.warn('Failed to update purchase order total after item exclusion:', poUpdateError)
+    }
+
+    return NextResponse.json({ success: true, item: updated, total_amount: totalAmount })
+  } catch (error) {
+    console.error('Error updating purchase order item exclusion:', error)
+    return NextResponse.json(
+      { error: 'Failed to update item exclusion', details: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/admin/CostCalculator.tsx
+++ b/src/components/admin/CostCalculator.tsx
@@ -1,0 +1,31 @@
+import { useMemo } from 'react'
+
+interface CostCalculatorProps {
+  packSize: number
+  packPrice: number
+  onUnitCost: (unitCost: number) => void
+}
+
+export function CostCalculator({ packSize, packPrice, onUnitCost }: CostCalculatorProps) {
+  const unitCost = useMemo(() => {
+    const size = Number(packSize) || 1
+    const price = Number(packPrice) || 0
+    if (!Number.isFinite(size) || size <= 0) return 0
+    return price / size
+  }, [packSize, packPrice])
+
+  return (
+    <div className="text-xs text-gray-700 space-y-1">
+      <div>Pack size: {packSize || 1}</div>
+      <div>Pack cost: ${Number(packPrice || 0).toFixed(2)}</div>
+      <div>Unit cost (pack ÷ size): ${unitCost.toFixed(2)}</div>
+      <button
+        type="button"
+        className="text-indigo-600 underline"
+        onClick={() => onUnitCost(Number(unitCost.toFixed(2)))}
+      >
+        Apply unit cost
+      </button>
+    </div>
+  )
+}

--- a/src/components/admin/InventoryEditModal.tsx
+++ b/src/components/admin/InventoryEditModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Save } from 'lucide-react'
 import toast from 'react-hot-toast'
+import { CostCalculator } from './CostCalculator'
 
 interface InventoryItem {
   id: string
@@ -14,6 +15,7 @@ interface InventoryItem {
   reorder_point: number
   unit_cost: number
   unit_type: string
+  pack_size?: number
   is_ingredient: boolean
   item_type?: 'ingredient' | 'prepackaged' | 'prepared' | 'supply'
   auto_decrement?: boolean
@@ -45,16 +47,23 @@ const UNIT_TYPES = [
 
 export default function InventoryEditModal({ item, suppliers, isOpen, onClose }: InventoryEditModalProps) {
   const [formData, setFormData] = useState<Partial<InventoryItem>>({})
+  const [packPrice, setPackPrice] = useState<string>('0')
+  const [costHistory, setCostHistory] = useState<any[]>([])
   const queryClient = useQueryClient()
 
   useEffect(() => {
     if (item && isOpen) {
+      const isPack = (item.pack_size || 1) > 1
+      // Stored unit_cost is per-unit; derive pack cost when pack size > 1
+      const initialPackPrice = isPack ? (item.unit_cost || 0) * (item.pack_size || 1) : (item.unit_cost || 0)
+      const derivedUnitCost = item.unit_cost || 0
       setFormData({
         item_name: item.item_name,
         minimum_threshold: item.minimum_threshold,
         reorder_point: item.reorder_point,
-        unit_cost: item.unit_cost,
+        unit_cost: derivedUnitCost,
         unit_type: item.unit_type,
+        pack_size: item.pack_size || 1,
         supplier_id: item.supplier_id || '',
         location: item.location,
         notes: item.notes || '',
@@ -62,8 +71,20 @@ export default function InventoryEditModal({ item, suppliers, isOpen, onClose }:
         item_type: item.item_type || (item.is_ingredient ? 'ingredient' : 'prepackaged'),
         auto_decrement: item.auto_decrement ?? false
       })
+      setPackPrice(initialPackPrice.toString())
+      loadCostHistory(item.id)
     }
   }, [item, isOpen])
+
+  const loadCostHistory = async (itemId: string) => {
+    try {
+      const res = await fetch(`/api/admin/inventory/cost-history?id=${itemId}&limit=5`)
+      const json = await res.json()
+      if (json.success) setCostHistory(json.history || [])
+    } catch (err) {
+      console.error('Failed to load cost history', err)
+    }
+  }
 
   const updateItemMutation = useMutation({
     mutationFn: async (data: Partial<InventoryItem>) => {
@@ -115,6 +136,11 @@ export default function InventoryEditModal({ item, suppliers, isOpen, onClose }:
 
     if (formData.unit_cost !== undefined && formData.unit_cost < 0) {
       toast.error('Unit cost cannot be negative')
+      return
+    }
+
+    if (formData.pack_size !== undefined && formData.pack_size <= 0) {
+      toast.error('Pack size must be at least 1')
       return
     }
 
@@ -186,24 +212,33 @@ export default function InventoryEditModal({ item, suppliers, isOpen, onClose }:
             </div>
           </div>
 
-          {/* Unit Cost and Type */}
+          {/* Cost & Units */}
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Unit Cost ($)
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Pack Size
               </label>
               <input
                 type="number"
-                min="0"
-                step="0.01"
-                value={formData.unit_cost || ''}
-                onChange={(e) => setFormData(prev => ({ ...prev, unit_cost: parseFloat(e.target.value) || 0 }))}
+                min="1"
+                step="1"
+                value={formData.pack_size ?? 1}
+                onChange={(e) => {
+                  const newSize = Math.max(1, parseInt(e.target.value, 10) || 1)
+                  const packPriceNum = Number(packPrice) || 0
+                  setFormData(prev => ({
+                    ...prev,
+                    pack_size: newSize,
+                    unit_cost: newSize > 0 ? packPriceNum / newSize : prev.unit_cost
+                  }))
+                }}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                placeholder="0.00"
+                placeholder="e.g., 24"
               />
+              <p className="text-xs text-gray-500 mt-1">Units per supplier pack/case.</p>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
                 Unit Type
               </label>
               <select
@@ -220,6 +255,53 @@ export default function InventoryEditModal({ item, suppliers, isOpen, onClose }:
             </div>
           </div>
 
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Unit Cost ($ each)
+              </label>
+              <input
+                type="number"
+                min="0"
+                step="0.0001"
+                value={formData.unit_cost ?? ''}
+                onChange={(e) => {
+                  const unitCost = parseFloat(e.target.value) || 0
+                  const packSize = formData.pack_size || 1
+                  setFormData(prev => ({ ...prev, unit_cost: unitCost }))
+                  setPackPrice((unitCost * packSize).toFixed(4))
+                }}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                placeholder="0.00"
+              />
+              <p className="text-xs text-gray-500 mt-1">Per-unit cost used in stock calculations.</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Pack Cost ($)
+              </label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={packPrice}
+                onChange={(e) => {
+                  const val = e.target.value
+                  const packCost = parseFloat(val) || 0
+                  const packSize = formData.pack_size || 1
+                  setPackPrice(val)
+                  setFormData(prev => ({
+                    ...prev,
+                    unit_cost: packSize > 0 ? Number((packCost / packSize).toFixed(2)) : prev.unit_cost
+                  }))
+                }}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                placeholder="e.g., 19.76"
+                disabled={(formData.pack_size || 1) <= 1}
+              />
+              <p className="text-xs text-gray-500 mt-1">Full pack/case price; auto-derives unit cost.</p>
+            </div>
+          </div>
           {/* Supplier */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -291,6 +373,93 @@ export default function InventoryEditModal({ item, suppliers, isOpen, onClose }:
               <label htmlFor="auto_decrement" className="block text-sm text-gray-700">
                 Auto sync stock from sales (for pre-packaged items)
               </label>
+            </div>
+          </div>
+
+          {/* Pack calculator and cost history */}
+          <div className="space-y-3">
+            <div className="rounded-lg border p-3 bg-gray-50">
+              <label className="block text-sm font-medium text-gray-700 mb-2">Pack → Unit Calculator</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Pack Cost ($)</label>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={packPrice}
+                onChange={(e) => {
+                  const val = e.target.value
+                  const packCost = parseFloat(val) || 0
+                  const packSize = formData.pack_size || 1
+                  setPackPrice(val)
+                  setFormData(prev => ({
+                    ...prev,
+                    unit_cost: packSize > 0 ? packCost / packSize : prev.unit_cost
+                  }))
+                }}
+                className="w-full rounded-md border px-2 py-1 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 mb-2"
+                placeholder="e.g. 4.17"
+              />
+              <CostCalculator
+                packSize={Number(formData.pack_size) || 1}
+                packPrice={Number(packPrice) || 0}
+                onUnitCost={(val) => {
+                  const packSize = formData.pack_size || 1
+                  const roundedUnit = Number(val.toFixed(2))
+                  setFormData(prev => ({ ...prev, unit_cost: roundedUnit }))
+                  setPackPrice((roundedUnit * packSize).toFixed(2))
+                }}
+              />
+            </div>
+
+            <div className="rounded-lg border p-3 bg-gray-50">
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-sm font-medium text-gray-700">Recent Cost Changes</div>
+                <button
+                  type="button"
+                  className="text-xs text-indigo-600 underline"
+                  onClick={() => loadCostHistory(item.id)}
+                >
+                  Refresh
+                </button>
+              </div>
+              {costHistory.length === 0 ? (
+                <p className="text-xs text-gray-500">No history yet.</p>
+              ) : (
+                <div className="space-y-1">
+                  {costHistory.map((h, idx) => (
+                    <div key={idx} className="flex items-center justify-between text-xs text-gray-700">
+                      <div>
+                        {new Date(h.changed_at).toLocaleDateString()} • {h.source}
+                        <div className="text-gray-500">
+                          {h.previous_unit_cost ?? '—'} → {h.new_unit_cost} (pack {h.pack_size || 1})
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        className="text-indigo-600 underline"
+                        onClick={async () => {
+                          const res = await fetch('/api/admin/inventory/revert-cost', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ item_id: item.id, target_cost: h.new_unit_cost, note: 'Revert from history' })
+                          })
+                          const json = await res.json()
+                          if (json.success) {
+                            toast.success('Unit cost reverted')
+                            setFormData(prev => ({ ...prev, unit_cost: h.new_unit_cost }))
+                            loadCostHistory(item.id)
+                            queryClient.invalidateQueries({ queryKey: ['admin-inventory'] })
+                          } else {
+                            toast.error(json.error || 'Failed to revert cost')
+                          }
+                        }}
+                      >
+                        Revert
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/components/admin/POCostHistoryTooltip.tsx
+++ b/src/components/admin/POCostHistoryTooltip.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+
+type Entry = {
+  changed_at: string
+  previous_unit_cost: number | null
+  new_unit_cost: number
+  pack_size: number | null
+  source: string
+}
+
+export function POCostHistoryTooltip({ itemId }: { itemId: string }) {
+  const [entries, setEntries] = useState<Entry[]>([])
+
+  useEffect(() => {
+    let active = true
+    const load = async () => {
+      const res = await fetch(`/api/admin/inventory/cost-history?id=${itemId}&limit=5`)
+      const json = await res.json()
+      if (json.success && active) setEntries(json.history || [])
+    }
+    if (itemId) load()
+    return () => {
+      active = false
+    }
+  }, [itemId])
+
+  if (!itemId || entries.length === 0) return null
+
+  return (
+    <div className="text-xs text-gray-600 space-y-1">
+      {entries.map((e, idx) => (
+        <div key={idx} className="flex items-center justify-between">
+          <span>{new Date(e.changed_at).toLocaleDateString()} • {e.source}</span>
+          <span>{e.previous_unit_cost ?? '—'} → {e.new_unit_cost} (pack {e.pack_size || 1})</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/admin/PurchaseOrderModal.tsx
+++ b/src/components/admin/PurchaseOrderModal.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { Button } from '@/components/ui'
 import { X, Plus, Trash2, Package, Building2, Calendar, Search, ChevronDown } from 'lucide-react'
 import toast from 'react-hot-toast'
+import { CostCalculator } from './CostCalculator'
 
 interface PurchaseOrderItem {
   id?: string
@@ -14,6 +15,12 @@ interface PurchaseOrderItem {
   unit_cost: number
   total_cost: number
   unit_type?: string
+  ordered_pack_qty?: number | null
+  pack_size?: number | null
+  pack_price?: number | null
+  order_unit?: 'each' | 'pack'
+  is_excluded?: boolean
+  exclusion_reason?: string | null
 }
 
 interface PurchaseOrder {
@@ -155,7 +162,53 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
     notes: '',
     items: [] as PurchaseOrderItem[]
   })
+  const [quickAddOpen, setQuickAddOpen] = useState(true)
+  const [openCalc, setOpenCalc] = useState<Record<number, boolean>>({})
   const [bulkSelections, setBulkSelections] = useState<Record<string, { selected: boolean; quantity: number }>>({})
+
+  const deriveCosts = (invItem: any) => {
+    const packSize = invItem?.pack_size || 1
+    let unitCost = invItem?.unit_cost || 0
+    let packPrice = invItem?.pack_price ?? null
+
+    if (packSize <= 1) {
+      return { packSize, packPrice: null, unitCost: Number(unitCost.toFixed(2)) }
+    }
+
+    if (packPrice == null) {
+      const candidate = Number((unitCost * packSize).toFixed(2))
+      // Heuristic:
+      // - If unitCost is modest and multiplying by packSize gives a plausible pack price, treat unitCost as per-unit.
+      // - Otherwise assume unitCost was stored as pack price.
+      if (unitCost <= 10 || candidate <= unitCost) {
+        packPrice = candidate
+      } else {
+        packPrice = Number(unitCost.toFixed(2))
+        unitCost = Number((packPrice / packSize).toFixed(2))
+      }
+    }
+
+    // Final normalize
+    packPrice = Number((packPrice ?? 0).toFixed(2))
+    unitCost = Number(((packPrice || unitCost * packSize) / packSize).toFixed(2))
+
+    return { packSize, packPrice, unitCost }
+  }
+
+  const computeLineTotal = (it: PurchaseOrderItem) => {
+    if (it.order_unit === 'pack') {
+      const packs = it.ordered_pack_qty ?? 0
+      const packSize = it.pack_size || 1
+      const packPrice = it.pack_price ?? it.unit_cost * packSize
+      return packs * packPrice
+    }
+    return (it.quantity_ordered || 0) * (it.unit_cost || 0)
+  }
+
+  const normalizeItem = (it: PurchaseOrderItem) => ({
+    ...it,
+    total_cost: computeLineTotal(it)
+  })
 
   const queryClient = useQueryClient()
 
@@ -188,6 +241,14 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
   const suppliers = suppliersData?.suppliers || []
   const inventoryItems = inventoryData?.items || []
   const selectedSupplier = suppliers.find((supplier: any) => supplier.id === formData.supplier_id)
+
+  const getRecommendedQuantity = (inventoryItemId: string) => {
+    const invItem = inventoryItems.find((inv: any) => inv.id === inventoryItemId)
+    if (!invItem) return 1
+    const gap = (invItem.reorder_point || 0) - (invItem.current_stock || 0)
+    const reorderQty = gap > 0 ? gap : invItem.reorder_point || 1
+    return Math.max(1, reorderQty)
+  }
 
   const orderableItems = useMemo(() => {
     if (!formData.supplier_id) return []
@@ -297,15 +358,19 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
     saveMutation.mutate(formData)
   }
 
-  const addItem = () => {
+const addItem = () => {
     setFormData(prev => ({
       ...prev,
-      items: [...prev.items, {
+      items: [...prev.items, normalizeItem({
         inventory_item_id: '',
         quantity_ordered: 1,
         unit_cost: 0,
-        total_cost: 0
-      }]
+        total_cost: 0,
+        pack_size: 1,
+        ordered_pack_qty: 1,
+        pack_price: 0,
+        order_unit: 'each'
+      })]
     }))
   }
 
@@ -321,32 +386,81 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
       ...prev,
       items: prev.items.map((item, i) => {
         if (i !== index) return item
-        
-        const updatedItem = { ...item, [field]: value }
-        
-        // Auto-calculate total cost
-        if (field === 'quantity_ordered') {
-          updatedItem.total_cost = updatedItem.quantity_ordered * updatedItem.unit_cost
+        let updatedItem = { ...item, [field]: value }
+
+       // Switching units
+       if (field === 'order_unit') {
+         const packSize = updatedItem.pack_size || 1
+         if (value === 'pack') {
+           const packs = Math.max(1, Math.round((updatedItem.quantity_ordered || 1) / packSize))
+           updatedItem.ordered_pack_qty = packs
+           updatedItem.quantity_ordered = packs * packSize
+         } else {
+           updatedItem.ordered_pack_qty = null
+         }
+       }
+
+       // In pack mode, quantity input should be packs
+       if (updatedItem.order_unit === 'pack') {
+          if (field === 'quantity_ordered') {
+            const packSize = updatedItem.pack_size || 1
+            const packs = Number(value) || 0
+            updatedItem.ordered_pack_qty = packs
+            updatedItem.quantity_ordered = packs * packSize
+          }
+          if (field === 'ordered_pack_qty') {
+            const packSize = updatedItem.pack_size || 1
+            const packs = Number(value) || 0
+            updatedItem.ordered_pack_qty = packs
+            updatedItem.quantity_ordered = packs * packSize
+          }
+          if (field === 'pack_price') {
+            const packSize = updatedItem.pack_size || 1
+            const packPrice = Number(value) || 0
+            const unit = packSize > 0 ? Number((packPrice / packSize).toFixed(2)) : updatedItem.unit_cost
+            updatedItem.unit_cost = unit
+            updatedItem.pack_price = Number(packPrice.toFixed(2))
+          }
+          if (field === 'unit_cost') {
+            const packSize = updatedItem.pack_size || 1
+            const unit = Number(value) || 0
+            updatedItem.unit_cost = Number(unit.toFixed(2))
+            updatedItem.pack_price = Number((unit * packSize).toFixed(2))
+          }
         }
-        
+
         // Auto-fill unit cost from inventory item
         if (field === 'inventory_item_id') {
           const inventoryItem = inventoryItems.find((inv: any) => inv.id === value)
           if (inventoryItem) {
-            updatedItem.unit_cost = inventoryItem.unit_cost
-            updatedItem.total_cost = updatedItem.quantity_ordered * inventoryItem.unit_cost
+            const recommendedQty = getRecommendedQuantity(inventoryItem.id)
+            const shouldSetQuantity = item.quantity_ordered === 1 || !item.inventory_item_id
+            const { packSize, packPrice, unitCost } = deriveCosts(inventoryItem)
+            updatedItem.unit_cost = unitCost
+            updatedItem.pack_size = packSize
+            updatedItem.pack_price = packPrice
+            if (packSize > 1) {
+              updatedItem.order_unit = 'pack'
+              updatedItem.ordered_pack_qty = 1
+              updatedItem.quantity_ordered = (updatedItem.ordered_pack_qty || 1) * packSize
+            } else {
+              updatedItem.order_unit = 'each'
+              updatedItem.ordered_pack_qty = null
+              updatedItem.quantity_ordered = shouldSetQuantity ? recommendedQty : item.quantity_ordered
+            }
             updatedItem.inventory_item_name = inventoryItem.item_name
             updatedItem.unit_type = inventoryItem.unit_type
           }
         }
-        
+
+        updatedItem.total_cost = computeLineTotal(updatedItem)
         return updatedItem
       })
     }))
   }
 
   const calculateTotal = () => {
-    return formData.items.reduce((sum, item) => sum + item.total_cost, 0)
+    return formData.items.reduce((sum, item) => sum + computeLineTotal(item), 0)
   }
 
   const toggleBulkSelection = (itemId: string, recommended: number) => {
@@ -388,27 +502,57 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
         const inventoryItem = orderableItems.find((item: any) => item.id === itemId)
         if (!inventoryItem) return
         const quantity = data.quantity || 1
-        const unitCost = inventoryItem.unit_cost || 0
+        const { packSize, packPrice, unitCost } = deriveCosts(inventoryItem)
 
         if (existingMap.has(itemId)) {
           const idx = existingMap.get(itemId) as number
           const existing = existingItems[idx]
-          const newQuantity = existing.quantity_ordered + quantity
-          existingItems[idx] = {
-            ...existing,
-            quantity_ordered: newQuantity,
-            unit_cost: unitCost,
-            total_cost: newQuantity * unitCost
+          if (packSize > 1) {
+            const newPacks = (existing.ordered_pack_qty || 0) + quantity
+            existingItems[idx] = normalizeItem({
+              ...existing,
+              order_unit: 'pack',
+              ordered_pack_qty: newPacks,
+              quantity_ordered: newPacks * packSize,
+              unit_cost: Number(((packPrice ?? 0) / packSize).toFixed(2)),
+              pack_price: packPrice ?? 0
+            })
+          } else {
+            const newQuantity = existing.quantity_ordered + quantity
+            existingItems[idx] = normalizeItem({
+              ...existing,
+              quantity_ordered: newQuantity,
+              unit_cost: Number(unitCost.toFixed(2))
+            })
           }
         } else {
-          existingItems.push({
-            inventory_item_id: itemId,
-            inventory_item_name: inventoryItem.item_name,
-            quantity_ordered: quantity,
-            unit_cost: unitCost,
-            total_cost: quantity * unitCost,
-            unit_type: inventoryItem.unit_type
-          })
+          const roundedUnit = Number(unitCost.toFixed(2))
+          const roundedPack = Number((packPrice || roundedUnit * packSize).toFixed(2))
+          if (packSize > 1) {
+            existingItems.push(normalizeItem({
+              inventory_item_id: itemId,
+              inventory_item_name: inventoryItem.item_name,
+              order_unit: 'pack',
+              ordered_pack_qty: quantity,
+              quantity_ordered: quantity * packSize,
+              unit_cost: Number((roundedPack / packSize).toFixed(2)),
+              unit_type: inventoryItem.unit_type,
+              pack_size: packSize,
+              pack_price: roundedPack,
+              total_cost: 0
+            }))
+          } else {
+            existingItems.push(normalizeItem({
+              inventory_item_id: itemId,
+              inventory_item_name: inventoryItem.item_name,
+              quantity_ordered: quantity,
+              unit_cost: roundedUnit,
+              unit_type: inventoryItem.unit_type,
+              pack_size: packSize,
+              pack_price: roundedPack || null,
+              total_cost: 0
+            }))
+          }
         }
       })
 
@@ -464,15 +608,28 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
               </div>
 
               {formData.supplier_id && orderableItems.length > 0 && (
-                <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50/40 p-4 space-y-3">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                      <p className="text-sm font-medium text-primary-700">
-                        Quick add items from {selectedSupplier?.name || 'supplier'}
-                      </p>
-                      <p className="text-xs text-primary-700/70">
-                        Select multiple items and adjust quantities before adding them to this order.
-                      </p>
+                <div className="mb-4 rounded-lg border border-primary-200 bg-primary-50/40">
+                  <div className="flex items-center justify-between px-4 py-3 border-b border-primary-100">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setQuickAddOpen((prev) => !prev)}
+                        className="text-primary-700 hover:text-primary-900"
+                        aria-expanded={quickAddOpen}
+                        aria-controls="quick-add-panel"
+                      >
+                        <ChevronDown
+                          className={`w-4 h-4 transition-transform ${quickAddOpen ? 'rotate-180' : ''}`}
+                        />
+                      </button>
+                      <div>
+                        <p className="text-sm font-medium text-primary-700">
+                          Quick add items from {selectedSupplier?.name || 'supplier'}
+                        </p>
+                        <p className="text-xs text-primary-700/70">
+                          Select multiple items and adjust quantities before adding them to this order.
+                        </p>
+                      </div>
                     </div>
                     <Button
                       type="button"
@@ -485,91 +642,99 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
                     </Button>
                   </div>
 
-                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                    {orderableItems.slice(0, 18).map((invItem: any) => {
-                      const selection = bulkSelections[invItem.id] || { selected: false, quantity: invItem.recommendedQuantity }
-                      const quantityValue = selection.quantity ?? invItem.recommendedQuantity ?? 1
-                      const reorderGap = (invItem.reorder_point || 0) - (invItem.current_stock || 0)
-                      return (
-                        <label
-                          key={invItem.id}
-                          className={`flex items-start gap-3 rounded-md border p-3 text-sm shadow-sm transition-colors ${
-                            selection.selected ? 'border-primary-300 bg-white' : 'border-gray-200 bg-white'
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            className="mt-1 h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
-                            checked={selection.selected}
-                            onChange={() => toggleBulkSelection(invItem.id, invItem.recommendedQuantity)}
-                          />
-                          <div className="flex-1 space-y-1">
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="font-medium text-gray-900">{invItem.item_name}</span>
-                              <span className="text-xs text-gray-500">{invItem.unit_type}</span>
-                            </div>
-                            <div className="text-xs text-gray-500">
-                              Stock: {invItem.current_stock ?? 0}{' '}
-                              {typeof invItem.reorder_point === 'number' && (
-                                <>| Reorder at {invItem.reorder_point}</>
-                              )}
-                              {reorderGap > 0 && (
-                                <span className="ml-2 text-primary-600">Needs +{reorderGap}</span>
-                              )}
-                            </div>
-                            <div className="flex items-center gap-2 text-xs text-gray-600">
-                              <span>Quantity:</span>
+                  {quickAddOpen && (
+                    <div id="quick-add-panel" className="p-4">
+                      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                        {orderableItems.slice(0, 18).map((invItem: any) => {
+                          const selection = bulkSelections[invItem.id] || { selected: false, quantity: invItem.recommendedQuantity }
+                          const quantityValue = selection.quantity ?? invItem.recommendedQuantity ?? 1
+                          const reorderGap = (invItem.reorder_point || 0) - (invItem.current_stock || 0)
+                          return (
+                            <label
+                              key={invItem.id}
+                              className={`flex items-start gap-3 rounded-md border p-3 text-sm shadow-sm transition-colors ${
+                                selection.selected ? 'border-primary-300 bg-white' : 'border-gray-200 bg-white'
+                              }`}
+                            >
                               <input
-                                type="number"
-                                min="1"
-                                value={quantityValue > 0 ? quantityValue : ''}
-                                disabled={!selection.selected}
-                                onChange={(e) => {
-                                  if (!selection.selected) return
-                                  const raw = e.target.value
-                                  if (raw === '') {
-                                    updateBulkQuantity(invItem.id, 0)
-                                    return
-                                  }
-                                  const parsed = Number.parseInt(raw, 10)
-                                  updateBulkQuantity(invItem.id, Number.isNaN(parsed) ? 0 : parsed)
-                                }}
-                                onBlur={(e) => {
-                                  if (!selection.selected) return
-                                  const raw = e.target.value
-                                  let parsed = Number.parseInt(raw, 10)
-                                  if (Number.isNaN(parsed) || parsed < 1) {
-                                    parsed = 1
-                                  }
-                                  updateBulkQuantity(invItem.id, parsed)
-                                }}
-                                className="w-20 rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-gray-100"
+                                type="checkbox"
+                                className="mt-1 h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                                checked={selection.selected}
+                                onChange={() => toggleBulkSelection(invItem.id, invItem.recommendedQuantity)}
                               />
-                              {invItem.unit_cost > 0 && (
-                                <span className="text-gray-400">${invItem.unit_cost.toFixed(2)} ea</span>
-                              )}
-                            </div>
+                              <div className="flex-1 space-y-1">
+                                <div className="flex items-center justify-between gap-2">
+                                  <span className="font-medium text-gray-900">{invItem.item_name}</span>
+                                  <span className="text-xs text-gray-500">{invItem.unit_type}</span>
+                                </div>
+                                <div className="text-xs text-gray-500">
+                                  Stock: {invItem.current_stock ?? 0}{' '}
+                                  {typeof invItem.reorder_point === 'number' && (
+                                    <>| Reorder at {invItem.reorder_point}</>
+                                  )}
+                                  {reorderGap > 0 && (
+                                    <span className="ml-2 text-primary-600">Needs +{reorderGap}</span>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-2 text-xs text-gray-600">
+                                  <span>Quantity:</span>
+                                  <input
+                                    type="number"
+                                    min="1"
+                                    value={quantityValue > 0 ? quantityValue : ''}
+                                    disabled={!selection.selected}
+                                    onChange={(e) => {
+                                      if (!selection.selected) return
+                                      const raw = e.target.value
+                                      if (raw === '') {
+                                        updateBulkQuantity(invItem.id, 0)
+                                        return
+                                      }
+                                      const parsed = Number.parseInt(raw, 10)
+                                      updateBulkQuantity(invItem.id, Number.isNaN(parsed) ? 0 : parsed)
+                                    }}
+                                    onBlur={(e) => {
+                                      if (!selection.selected) return
+                                      const raw = e.target.value
+                                      let parsed = Number.parseInt(raw, 10)
+                                      if (Number.isNaN(parsed) || parsed < 1) {
+                                        parsed = 1
+                                      }
+                                      updateBulkQuantity(invItem.id, parsed)
+                                    }}
+                                    className="w-20 rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 disabled:bg-gray-100"
+                                  />
+                                  {(() => {
+                                    const { packSize, packPrice, unitCost } = deriveCosts(invItem)
+                                    const displayPrice = packSize > 1 ? packPrice : unitCost
+                                    return displayPrice > 0 ? (
+                                      <span className="text-gray-400">
+                                        ${displayPrice.toFixed(2)} {packSize > 1 ? 'per pack' : 'ea'}
+                                      </span>
+                                    ) : null
+                                  })()}
+                                </div>
+                              </div>
+                            </label>
+                          )
+                        })}
+                        {orderableItems.length > 18 && (
+                          <div className="text-xs text-gray-500">
+                            Showing top 18 items. Use "Add Item" to select others.
                           </div>
-                        </label>
-                      )
-                    })}
-                    {orderableItems.length > 18 && (
-                      <div className="text-xs text-gray-500">
-                        Showing top 18 items. Use "Add Item" to select others.
+                        )}
                       </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
                 </div>
               )}
 
               <div className="space-y-4">
                 {formData.items.map((item, index) => (
                   <div key={index} className="border border-gray-200 rounded-lg p-4">
-                    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
-                      <div className="md:col-span-2">
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          Inventory Item *
-                        </label>
+                    <div className="grid grid-cols-12 gap-3 items-center">
+                      <div className="col-span-5">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Inventory Item *</label>
                         {formData.supplier_id ? (
                           <SearchableDropdown
                             items={orderableItems}
@@ -585,55 +750,166 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
                         )}
                       </div>
 
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          Quantity *
-                        </label>
+                      <div className="col-span-3">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Quantity *</label>
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="number"
+                            min="1"
+                            step="1"
+                            value={
+                              item.order_unit === 'pack'
+                                ? (item.ordered_pack_qty ?? Math.max(1, Math.round((item.quantity_ordered || 1) / (item.pack_size || 1))))
+                                : item.quantity_ordered > 0 ? item.quantity_ordered : ''
+                            }
+                            onChange={(e) => {
+                              const raw = e.target.value
+                              const parsed = raw === '' ? 0 : Number.parseInt(raw, 10)
+                              const safeQty = Number.isNaN(parsed) ? 0 : parsed
+                              if (item.order_unit === 'pack') {
+                                updateItem(index, 'ordered_pack_qty', safeQty)
+                              } else {
+                                updateItem(index, 'quantity_ordered', safeQty)
+                              }
+                            }}
+                            onBlur={() => {
+                              if (item.order_unit === 'pack') {
+                                if ((item.ordered_pack_qty ?? 0) < 1) updateItem(index, 'ordered_pack_qty', 1)
+                              } else if (item.quantity_ordered < 1) {
+                                updateItem(index, 'quantity_ordered', 1)
+                              }
+                            }}
+                            className="w-20 px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                            required
+                          />
+                          <select
+                            value={item.order_unit || 'each'}
+                            onChange={(e) => {
+                              const nextUnit = e.target.value as 'each' | 'pack'
+                              setFormData(prev => ({
+                                ...prev,
+                                items: prev.items.map((it, i) => {
+                                  if (i !== index) return it
+                                  const packSize = it.pack_size || 1
+                                  const orderedPackQty = nextUnit === 'pack' ? (it.ordered_pack_qty || 1) : undefined
+                                  const quantityOrdered =
+                                    nextUnit === 'pack'
+                                      ? (orderedPackQty || 1) * packSize
+                                      : it.quantity_ordered || 1
+                                  return {
+                                    ...it,
+                                    order_unit: nextUnit,
+                                    ordered_pack_qty: orderedPackQty,
+                                    quantity_ordered: quantityOrdered,
+                                    total_cost: quantityOrdered * it.unit_cost
+                                  }
+                                })
+                              }))
+                            }}
+                            className="text-sm border border-gray-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                          >
+                            <option value="each">Each</option>
+                            <option value="pack">Pack of {item.pack_size || 1}</option>
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className="col-span-2">
+                        <div className="flex items-center justify-between">
+                          <label className="block text-sm font-medium text-gray-700 mb-1">
+                            {item.order_unit === 'pack' ? 'Pack Cost' : 'Unit Cost'}
+                          </label>
+                          <button
+                            type="button"
+                            className="text-indigo-600 underline text-xs"
+                            onClick={() => setOpenCalc(prev => ({ ...prev, [index]: !prev[index] }))}
+                          >
+                            Calc
+                          </button>
+                        </div>
                         <input
                           type="number"
-                          min="1"
-                          step="1"
-                          value={item.quantity_ordered > 0 ? item.quantity_ordered : ''}
+                          min="0"
+                          step="0.01"
+                          value={
+                            item.order_unit === 'pack'
+                              ? (item.pack_price ?? Number(((item.unit_cost || 0) * (item.pack_size || 1)).toFixed(2)))
+                              : item.unit_cost
+                          }
                           onChange={(e) => {
-                            const raw = e.target.value
-                            if (raw === '') {
-                              updateItem(index, 'quantity_ordered', 0)
-                              return
-                            }
-                            const parsed = Number.parseInt(raw, 10)
-                            updateItem(index, 'quantity_ordered', Number.isNaN(parsed) ? 0 : parsed)
-                          }}
-                          onBlur={() => {
-                            if (item.quantity_ordered < 1) {
-                              updateItem(index, 'quantity_ordered', 1)
+                            const val = Number(e.target.value) || 0
+                            if (item.order_unit === 'pack') {
+                              updateItem(index, 'pack_price', val)
+                            } else {
+                              updateItem(index, 'unit_cost', val)
                             }
                           }}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                          required
+                          className="w-full px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                         />
+                        {openCalc[index] && (
+                          <div className="mt-2 p-3 rounded-md border border-gray-200 bg-white shadow-sm space-y-2">
+                            <label className="block text-xs font-medium text-gray-700">Pack Cost ($)</label>
+                            <input
+                              type="number"
+                              min="0"
+                              step="0.01"
+                              value={item.pack_price ?? ''}
+                              onChange={(e) => {
+                                const packPrice = Number(e.target.value) || 0
+                                setFormData(prev => ({
+                                  ...prev,
+                                  items: prev.items.map((it, i) => {
+                                    if (i !== index) return it
+                                    const packSize = it.pack_size || 1
+                                    const unitCost = packSize > 0 ? packPrice / packSize : it.unit_cost
+                                    const quantityOrdered = it.order_unit === 'pack'
+                                      ? (it.ordered_pack_qty || 1) * packSize
+                                      : it.quantity_ordered || 1
+                                    return {
+                                      ...it,
+                                      pack_price: packPrice,
+                                      unit_cost: unitCost,
+                                      total_cost: quantityOrdered * unitCost
+                                    }
+                                  })
+                                }))
+                              }}
+                              className="w-full px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
+                              placeholder="4.17"
+                            />
+                            <CostCalculator
+                              packSize={item.pack_size || 1}
+                              packPrice={item.pack_price || 0}
+                              onUnitCost={(val) => {
+                                setFormData(prev => ({
+                                  ...prev,
+                                  items: prev.items.map((it, i) => {
+                                    if (i !== index) return it
+                                    const packSize = it.pack_size || 1
+                                    const quantityOrdered = it.order_unit === 'pack'
+                                      ? (it.ordered_pack_qty || 1) * packSize
+                                      : it.quantity_ordered || 1
+                                    const roundedUnit = Number(val.toFixed(2))
+                                    const roundedPack = Number((roundedUnit * packSize).toFixed(2))
+                                    return {
+                                      ...it,
+                                      unit_cost: roundedUnit,
+                                      pack_price: roundedPack,
+                                      total_cost: quantityOrdered * roundedUnit
+                                    }
+                                  })
+                                }))
+                              }}
+                            />
+                          </div>
+                        )}
                       </div>
 
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          Unit Cost
-                        </label>
-                        <input
-                          type="text"
-                          value={`$${item.unit_cost.toFixed(2)}`}
-                          readOnly
-                          className="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-gray-600 cursor-not-allowed"
-                        />
-                      </div>
-
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">
-                            Total
-                          </label>
-                          <span className="text-lg font-semibold text-gray-900">
-                            ${item.total_cost.toFixed(2)}
-                          </span>
+                      <div className="col-span-2 flex flex-col items-end gap-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-gray-700">Total</span>
                         </div>
+                        <div className="text-lg font-semibold text-gray-900">${item.total_cost.toFixed(2)}</div>
                         <Button
                           type="button"
                           variant="ghost"
@@ -641,7 +917,7 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
                           onClick={() => removeItem(index)}
                           className="text-red-600 hover:text-red-800 hover:bg-red-50"
                         >
-                          <Trash2 className="w-4 h-4" />
+                          <Trash2 className="w-4 h-4 mr-1" /> Remove
                         </Button>
                       </div>
                     </div>
@@ -730,132 +1006,6 @@ const PurchaseOrderModal = ({ order, isOpen, onClose }: PurchaseOrderModalProps)
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                 placeholder="Add any notes about this purchase order..."
               />
-            </div>
-
-            {/* Items Section */}
-            <div>
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-medium text-gray-900">Order Items</h3>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={addItem}
-                  className="text-primary-600 border-primary-600 hover:bg-primary-50"
-                >
-                  <Plus className="w-4 h-4 mr-2" />
-                  Add Item
-                </Button>
-              </div>
-
-              <div className="space-y-4">
-                {formData.items.map((item, index) => (
-                  <div key={index} className="border border-gray-200 rounded-lg p-4">
-                    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
-                      <div className="md:col-span-2">
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          Inventory Item *
-                        </label>
-                        {formData.supplier_id ? (
-                          <SearchableDropdown
-                            items={inventoryItems.filter((invItem: any) => 
-                              invItem.supplier_id === formData.supplier_id &&
-                              invItem.item_type !== 'prepared'
-                            )}
-                            value={item.inventory_item_id}
-                            onChange={(value) => updateItem(index, 'inventory_item_id', value)}
-                            placeholder="Search and select an item"
-                            className="w-full"
-                          />
-                        ) : (
-                          <div className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-50 text-gray-500">
-                            Select a supplier first
-                          </div>
-                        )}
-                      </div>
-
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          Quantity *
-                        </label>
-                        <input
-                          type="number"
-                          min="1"
-                          step="1"
-                          value={item.quantity_ordered > 0 ? item.quantity_ordered : ''}
-                          onChange={(e) => {
-                            const raw = e.target.value
-                            if (raw === '') {
-                              updateItem(index, 'quantity_ordered', 0)
-                              return
-                            }
-                            const parsed = Number.parseInt(raw, 10)
-                            updateItem(index, 'quantity_ordered', Number.isNaN(parsed) ? 0 : parsed)
-                          }}
-                          onBlur={() => {
-                            if (item.quantity_ordered < 1) {
-                              updateItem(index, 'quantity_ordered', 1)
-                            }
-                          }}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                          required
-                        />
-                      </div>
-
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          Unit Cost
-                        </label>
-                        <input
-                          type="text"
-                          value={`$${item.unit_cost.toFixed(2)}`}
-                          readOnly
-                          className="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-gray-600 cursor-not-allowed"
-                        />
-                      </div>
-
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">
-                            Total
-                          </label>
-                          <span className="text-lg font-semibold text-gray-900">
-                            ${item.total_cost.toFixed(2)}
-                          </span>
-                        </div>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => removeItem(index)}
-                          className="text-red-600 hover:text-red-800 hover:bg-red-50"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-
-                {formData.items.length === 0 && (
-                  <div className="text-center py-8 text-gray-500">
-                    <Package className="w-12 h-12 mx-auto mb-4 text-gray-400" />
-                    <p className="text-lg font-medium mb-2">No items added yet</p>
-                    <p>Click "Add Item" to start building your purchase order</p>
-                  </div>
-                )}
-              </div>
-
-              {formData.items.length > 0 && (
-                <div className="mt-4 pt-4 border-t border-gray-200">
-                  <div className="flex justify-between items-center">
-                    <span className="text-lg font-medium text-gray-900">Total Amount:</span>
-                    <span className="text-xl font-bold text-primary-600">
-                      ${calculateTotal().toFixed(2)}
-                    </span>
-                  </div>
-                </div>
-              )}
             </div>
 
             {/* Form Actions */}

--- a/supabase/migrations/20251123120000_add_po_item_exclusions.sql
+++ b/supabase/migrations/20251123120000_add_po_item_exclusions.sql
@@ -1,0 +1,17 @@
+-- Add exclusion tracking to purchase order items
+alter table purchase_order_items
+  add column if not exists is_excluded boolean not null default false;
+
+alter table purchase_order_items
+  add column if not exists exclusion_reason text;
+
+alter table purchase_order_items
+  add column if not exists excluded_at timestamptz;
+
+alter table purchase_order_items
+  add column if not exists excluded_by uuid references auth.users (id);
+
+alter table purchase_order_items
+  add column if not exists exclusion_phase text check (exclusion_phase in ('pre_send','post_send','receiving'));
+
+create index if not exists purchase_order_items_is_excluded_idx on purchase_order_items (is_excluded);

--- a/supabase/migrations/20251123123000_add_inventory_deleted_at.sql
+++ b/supabase/migrations/20251123123000_add_inventory_deleted_at.sql
@@ -1,0 +1,4 @@
+alter table inventory_items
+  add column if not exists deleted_at timestamptz;
+
+create index if not exists inventory_items_deleted_at_idx on inventory_items (deleted_at);

--- a/supabase/migrations/20251123130000_add_pack_size_and_po_pack_qty.sql
+++ b/supabase/migrations/20251123130000_add_pack_size_and_po_pack_qty.sql
@@ -1,0 +1,9 @@
+-- Add pack_size to inventory items
+alter table inventory_items
+  add column if not exists pack_size numeric default 1;
+
+-- Add ordered_pack_qty to purchase order items
+alter table purchase_order_items
+  add column if not exists ordered_pack_qty numeric;
+
+create index if not exists purchase_order_items_ordered_pack_qty_idx on purchase_order_items (ordered_pack_qty);

--- a/supabase/migrations/20251123134500_update_inventory_unique_pack_size.sql
+++ b/supabase/migrations/20251123134500_update_inventory_unique_pack_size.sql
@@ -1,0 +1,13 @@
+-- Drop existing unique constraint on square_item_id
+alter table inventory_items
+  drop constraint if exists inventory_items_square_item_id_key;
+
+-- Ensure pack_size is not null with default 1
+alter table inventory_items
+  alter column pack_size set default 1,
+  alter column pack_size set not null;
+
+-- Add composite uniqueness on (square_item_id, pack_size) while allowing null square_item_id
+create unique index if not exists inventory_items_square_pack_unique
+  on inventory_items (square_item_id, pack_size)
+  where square_item_id is not null;

--- a/supabase/migrations/20251123141500_add_shift_inventory_function.sql
+++ b/supabase/migrations/20251123141500_add_shift_inventory_function.sql
@@ -1,0 +1,26 @@
+-- Atomic shift between two inventory items
+create or replace function public.shift_inventory_between_items(
+  p_from_item_id uuid,
+  p_to_item_id uuid,
+  p_quantity numeric
+) returns void
+language plpgsql
+as $$
+begin
+  if p_quantity <= 0 then
+    raise exception 'Quantity must be positive';
+  end if;
+
+  -- Decrement source
+  update inventory_items
+  set current_stock = current_stock - p_quantity
+  where id = p_from_item_id;
+
+  -- Increment target
+  update inventory_items
+  set current_stock = current_stock + p_quantity
+  where id = p_to_item_id;
+end;
+$$;
+
+comment on function public.shift_inventory_between_items is 'Moves quantity between two inventory_items atomically';

--- a/supabase/migrations/20251123143000_add_po_item_pack_size.sql
+++ b/supabase/migrations/20251123143000_add_po_item_pack_size.sql
@@ -1,0 +1,4 @@
+alter table purchase_order_items
+  add column if not exists pack_size numeric;
+
+create index if not exists purchase_order_items_pack_size_idx on purchase_order_items (pack_size);

--- a/supabase/migrations/20251126100000_make_receipts_info_only.sql
+++ b/supabase/migrations/20251126100000_make_receipts_info_only.sql
@@ -1,0 +1,134 @@
+-- Make purchase order receipts informational only (no stock mutation)
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.log_purchase_order_receipt(
+  p_purchase_order_id uuid,
+  p_purchase_order_item_id uuid,
+  p_quantity integer,
+  p_received_by uuid,
+  p_notes text DEFAULT NULL,
+  p_weight numeric DEFAULT NULL,
+  p_weight_unit text DEFAULT NULL,
+  p_photo_path text DEFAULT NULL,
+  p_photo_url text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  item_record RECORD;
+  new_receipt public.purchase_order_receipts%ROWTYPE;
+  remaining integer;
+  previous_status text;
+  canonical_previous text;
+  canonical_new text;
+  order_completed boolean := false;
+  remaining_count integer;
+BEGIN
+  IF p_quantity IS NULL OR p_quantity <= 0 THEN
+    RAISE EXCEPTION 'Quantity must be greater than zero';
+  END IF;
+
+  SELECT 
+    poi.*,
+    po.status AS order_status,
+    po.order_number
+  INTO item_record
+  FROM public.purchase_order_items poi
+  JOIN public.purchase_orders po ON po.id = poi.purchase_order_id
+  WHERE poi.id = p_purchase_order_item_id
+    AND poi.purchase_order_id = p_purchase_order_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Purchase order item % not found for order %', p_purchase_order_item_id, p_purchase_order_id;
+  END IF;
+
+  remaining := item_record.quantity_ordered - item_record.quantity_received;
+
+  IF remaining <= 0 THEN
+    RAISE EXCEPTION 'Purchase order item already fully received';
+  END IF;
+
+  IF p_quantity > remaining THEN
+    RAISE EXCEPTION 'Receipt quantity (%) exceeds remaining quantity (%)', p_quantity, remaining;
+  END IF;
+
+  INSERT INTO public.purchase_order_receipts (
+    purchase_order_id,
+    purchase_order_item_id,
+    quantity_received,
+    weight,
+    weight_unit,
+    notes,
+    photo_path,
+    photo_url,
+    received_by
+  )
+  VALUES (
+    p_purchase_order_id,
+    p_purchase_order_item_id,
+    p_quantity,
+    p_weight,
+    p_weight_unit,
+    p_notes,
+    p_photo_path,
+    p_photo_url,
+    p_received_by
+  )
+  RETURNING * INTO new_receipt;
+
+  -- Keep PO item receipt bookkeeping but do NOT mutate inventory stock here.
+  UPDATE public.purchase_order_items
+    SET quantity_received = quantity_received + p_quantity,
+        updated_at = timezone('utc'::text, now())
+    WHERE id = p_purchase_order_item_id;
+
+  SELECT COUNT(*)
+  INTO remaining_count
+  FROM public.purchase_order_items poi
+  WHERE poi.purchase_order_id = p_purchase_order_id
+    AND poi.quantity_received < poi.quantity_ordered;
+
+  order_completed := remaining_count = 0;
+
+  previous_status := item_record.order_status;
+  IF previous_status = 'confirmed' THEN
+    canonical_previous := 'approved';
+  ELSE
+    canonical_previous := previous_status;
+  END IF;
+
+  IF order_completed THEN
+    UPDATE public.purchase_orders
+      SET status = 'received',
+          actual_delivery_date = COALESCE(actual_delivery_date, timezone('utc'::text, now())),
+          updated_at = timezone('utc'::text, now())
+      WHERE id = p_purchase_order_id;
+
+    canonical_new := 'received';
+
+    IF canonical_previous IS DISTINCT FROM canonical_new THEN
+      INSERT INTO public.purchase_order_status_history (
+        purchase_order_id,
+        previous_status,
+        new_status,
+        changed_by,
+        note
+      ) VALUES (
+        p_purchase_order_id,
+        canonical_previous,
+        canonical_new,
+        p_received_by,
+        'Automatically marked as received after completing item receipts'
+      );
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'receipt', to_jsonb(new_receipt),
+    'order_completed', order_completed
+  );
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20251126104500_add_inventory_item_cost_history.sql
+++ b/supabase/migrations/20251126104500_add_inventory_item_cost_history.sql
@@ -1,0 +1,36 @@
+-- Track unit cost changes over time
+begin;
+
+create table if not exists public.inventory_item_cost_history (
+  id uuid primary key default gen_random_uuid(),
+  inventory_item_id uuid not null references public.inventory_items(id) on delete cascade,
+  previous_unit_cost numeric,
+  new_unit_cost numeric not null,
+  pack_size numeric default 1,
+  source text not null,
+  source_ref uuid,
+  notes text,
+  changed_by uuid,
+  changed_at timestamptz not null default timezone('utc'::text, now())
+);
+
+create index if not exists inventory_item_cost_history_item_idx
+  on public.inventory_item_cost_history (inventory_item_id, changed_at desc);
+
+alter table public.inventory_item_cost_history enable row level security;
+
+-- Simple policies for authenticated users (admin area) to read/insert history
+drop policy if exists "inventory_cost_history_read" on public.inventory_item_cost_history;
+drop policy if exists "inventory_cost_history_insert" on public.inventory_item_cost_history;
+
+create policy "inventory_cost_history_read"
+  on public.inventory_item_cost_history
+  for select
+  using (true);
+
+create policy "inventory_cost_history_insert"
+  on public.inventory_item_cost_history
+  for insert
+  with check (true);
+
+commit;


### PR DESCRIPTION
  - normalize pack/base item costs at invoice confirm; base items now take raw invoice unit price and find base rows even when pack_size is null
  - fix PO creation totals to use quantity_ordered * unit_cost (packs no longer undercount); PO view recomputes item totals in UI
  - unit cost calculator/history task complete; pack/unit calculators unified and rounded to cents
  - inventory overview shows pack price for packs; base items keep correct per-unit costs
  - add mobile kebab actions and filter toggle scaffold on PO list (task in progress)