### PR TITLE
cogs: add product codes and sheet recipe import

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ The system includes self-documenting API endpoints. Send GET requests to any API
 - `GET /api/square/config` - Square integration docs
 - `GET /api/webhooks/square/catalog` - Webhook documentation
 
+## COGS Recipes (Google Sheets)
+
+See `doc/cogs-recipes-sheets.md`.
+
 ## 🔐 Security Features
 
 - **Environment Variable Validation**: Runtime validation prevents build failures

--- a/doc/cogs-recipes-sheets.md
+++ b/doc/cogs-recipes-sheets.md
@@ -1,0 +1,41 @@
+# COGS Recipes (Google Sheets)
+
+Products remain sourced from Square and stored in `cogs_products`. Recipes can be imported from a master Google Sheet as CSV.
+
+## 1) Prereqs
+
+1. Sync products from Square in the admin UI (`/admin/cogs` → `Catalog` → “Sync from Square”).
+2. Assign a stable `product_code` for each product in the same Catalog table (example: `LATTE_12OZ`).
+3. Ensure inventory items exist in `inventory_items` and that ingredient names in the sheet match `inventory_items.item_name` exactly.
+
+## 2) Sheet format (single tab: `Recipes`)
+
+One row = one ingredient line.
+
+Required columns (exact header text is case-insensitive):
+
+- `Product Code` (e.g., `LATTE_12OZ`)
+- `Effective From` (YYYY-MM-DD)
+- `Yield Qty` (number, > 0)
+- `Yield Unit` (e.g., `each`)
+- `Ingredient Name` (must match `inventory_items.item_name` exactly)
+- `Ingredient Qty` (number, > 0)
+- `Ingredient Unit` (e.g., `oz`, `ml`, `each`)
+- `Loss %` (0–100)
+- `Recipe Notes` (optional)
+
+## 3) Publish as CSV
+
+The importer expects a CSV URL. The simplest approach is to publish the sheet and use the “CSV export” URL.
+
+## 4) Run importer
+
+Set `COGS_RECIPES_SHEET_CSV_URL` in `.env.local` (recommended) or pass `--csv-url`.
+
+- Dry run: `npm run import-cogs-recipes -- --dry-run`
+- Apply: `npm run import-cogs-recipes -- --apply`
+- Local file: `npm run import-cogs-recipes -- --dry-run --csv-path path/to/recipes.csv`
+
+Behavior:
+- Recipe headers are keyed by (`product_code`, `effective_from` at UTC midnight).
+- For each header, existing ingredient lines are deleted and re-inserted to match the sheet.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "upload-suppliers": "node scripts/bulk-upload-suppliers.js",
     "audit-square-mapping": "node scripts/audit-square-inventory-mapping.js",
     "fix-square-mapping": "node scripts/fix-square-inventory-mapping.js",
+    "import-cogs-recipes": "node scripts/import-cogs-recipes-from-sheets.js",
     "db:migrate": "npx supabase db push",
     "db:reset": "npx supabase db reset",
     "db:generate": "npx supabase gen types typescript --local",

--- a/scripts/import-cogs-recipes-from-sheets.js
+++ b/scripts/import-cogs-recipes-from-sheets.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/**
+ * Runner for scripts/import-cogs-recipes-from-sheets.ts (transpile on the fly).
+ */
+
+require('dotenv').config({ path: '.env.local' })
+
+const fs = require('fs')
+const path = require('path')
+const ts = require('typescript')
+const Module = module.constructor
+
+const entryPath = path.join(__dirname, 'import-cogs-recipes-from-sheets.ts')
+const source = fs.readFileSync(entryPath, 'utf8')
+
+const { outputText } = ts.transpileModule(source, {
+  fileName: entryPath,
+  compilerOptions: {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.CommonJS,
+    esModuleInterop: true,
+    resolveJsonModule: true
+  }
+})
+
+const compiledModule = new Module(entryPath, module.parent)
+compiledModule.filename = entryPath
+compiledModule.paths = Module._nodeModulePaths(path.dirname(entryPath))
+compiledModule._compile(outputText, entryPath)
+

--- a/scripts/import-cogs-recipes-from-sheets.ts
+++ b/scripts/import-cogs-recipes-from-sheets.ts
@@ -1,0 +1,549 @@
+#!/usr/bin/env node
+
+/**
+ * Import product base recipes from a Google Sheet (CSV export).
+ *
+ * - Source of truth for products remains Square (`cogs_products`).
+ * - Sheet defines recipes keyed by `cogs_products.product_code` and `inventory_items.item_name`.
+ * - Lines are replaced to match the sheet for each (product_code, effective_from) recipe header.
+ *
+ * Usage:
+ *  node scripts/import-cogs-recipes-from-sheets.js --dry-run
+ *  node scripts/import-cogs-recipes-from-sheets.js --apply
+ *
+ * Flags:
+ *  --dry-run              Print plan only (no writes) (default)
+ *  --apply                Apply changes
+ *  --env <path>           Env file path (default: .env.local)
+ *  --csv-url <url>        Override COGS_RECIPES_SHEET_CSV_URL env var
+ *  --csv-path <path>      Read CSV from a local file path (no network)
+ *
+ * Required env vars:
+ *  COGS_RECIPES_SHEET_CSV_URL (unless --csv-url provided)
+ *  SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL)
+ *  SUPABASE_SECRET_KEY (preferred) or SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import dotenv from 'dotenv'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import fs from 'fs'
+
+type Options = {
+  dryRun: boolean
+  envPath: string
+  csvUrl: string | null
+  csvPath: string | null
+}
+
+type RawRow = Record<string, string>
+
+type RecipeLineRow = {
+  productCode: string
+  effectiveFrom: string
+  yieldQty: number
+  yieldUnit: string
+  ingredientName: string
+  ingredientQty: number
+  ingredientUnit: string
+  lossPct: number
+  recipeNotes: string | null
+  rowNumber: number
+}
+
+type RecipeHeaderKey = `${string}__${string}` // productCode__effectiveFromIso
+
+type RecipeHeader = {
+  key: RecipeHeaderKey
+  productCode: string
+  effectiveFromIso: string
+  yieldQty: number
+  yieldUnit: string
+  recipeNotes: string | null
+  lines: Array<{
+    ingredientName: string
+    ingredientQty: number
+    ingredientUnit: string
+    lossPct: number
+    rowNumber: number
+  }>
+}
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = {
+    dryRun: true,
+    envPath: '.env.local',
+    csvUrl: null,
+    csvPath: null,
+  }
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--apply') options.dryRun = false
+    else if (arg === '--dry-run') options.dryRun = true
+    else if (arg === '--env') options.envPath = argv[i + 1] ?? '.env.local'
+    else if (arg === '--csv-url') options.csvUrl = argv[i + 1] ?? null
+    else if (arg === '--csv-path') options.csvPath = argv[i + 1] ?? null
+    else if (arg === '--help' || arg === '-h') {
+      printHelpAndExit(0)
+    } else {
+      console.error(`Unknown argument: ${arg}`)
+      printHelpAndExit(1)
+    }
+    if (arg === '--env' || arg === '--csv-url' || arg === '--csv-path') i += 1
+  }
+
+  return options
+}
+
+function printHelpAndExit(code: number) {
+  console.log(`
+Import COGS product base recipes from Google Sheets (CSV).
+
+Usage:
+  node scripts/import-cogs-recipes-from-sheets.js --dry-run
+  node scripts/import-cogs-recipes-from-sheets.js --apply
+
+Flags:
+  --dry-run              Print plan only (default)
+  --apply                Apply changes
+  --env <path>           Env file path (default: .env.local)
+  --csv-url <url>        Override COGS_RECIPES_SHEET_CSV_URL
+  --csv-path <path>      Read CSV from a local file path (no network)
+`)
+  process.exit(code)
+}
+
+function normalizeHeader(value: string) {
+  const withoutBom = value.replace(/^\uFEFF/, '')
+  return withoutBom
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, ' ')
+}
+
+function parseDelimitedLine(line: string, delimiter: ',' | '\t') {
+  const cells: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i]
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"'
+        i += 1
+      } else {
+        inQuotes = !inQuotes
+      }
+      continue
+    }
+    if (ch === delimiter && !inQuotes) {
+      cells.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  cells.push(current)
+  return cells.map(c => c.trim())
+}
+
+function detectDelimiter(headerLine: string): ',' | '\t' {
+  const commaCount = (headerLine.match(/,/g) || []).length
+  const tabCount = (headerLine.match(/\t/g) || []).length
+  return tabCount > commaCount ? '\t' : ','
+}
+
+function parseCsv(text: string): { rows: RawRow[]; headers: string[] } {
+  const cleaned = text.replace(/^\uFEFF/, '')
+  const lines = cleaned
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .filter(l => l.trim().length > 0)
+
+  if (lines.length === 0) return { rows: [], headers: [] }
+
+  const delimiter = detectDelimiter(lines[0])
+  const headerCells = parseDelimitedLine(lines[0], delimiter)
+  const headers = headerCells.map(normalizeHeader)
+
+  const rows: RawRow[] = []
+  for (let i = 1; i < lines.length; i += 1) {
+    const cells = parseDelimitedLine(lines[i], delimiter)
+    const row: RawRow = {}
+    for (let c = 0; c < headers.length; c += 1) {
+      row[headers[c]] = cells[c] ?? ''
+    }
+    rows.push(row)
+  }
+  return { rows, headers }
+}
+
+function normalizeText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function parseNumber(value: string, fallback: number) {
+  const cleaned = value.trim()
+  if (!cleaned) return fallback
+  const n = Number(cleaned)
+  return Number.isFinite(n) ? n : fallback
+}
+
+function parseDateToUtcMidnightIso(value: string) {
+  const raw = value.trim()
+  if (!raw) return null
+  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!m) return null
+  const [_, y, mo, d] = m
+  return new Date(`${y}-${mo}-${d}T00:00:00.000Z`).toISOString()
+}
+
+function toRecipeLineRow(row: RawRow, rowNumber: number) {
+  const productCode = normalizeText(row['product code'])
+  const effectiveFromIso = parseDateToUtcMidnightIso(normalizeText(row['effective from']))
+  const yieldQty = parseNumber(normalizeText(row['yield qty']), 1)
+  const yieldUnit = normalizeText(row['yield unit']) || 'each'
+  const ingredientName = normalizeText(row['ingredient name'])
+  const ingredientQty = parseNumber(normalizeText(row['ingredient qty']), NaN)
+  const ingredientUnit = normalizeText(row['ingredient unit']) || 'each'
+  const lossPct = parseNumber(normalizeText(row['loss %']), 0)
+  const recipeNotes = normalizeText(row['recipe notes']) || null
+
+  const errors: string[] = []
+  if (!productCode) errors.push('Missing Product Code')
+  if (!effectiveFromIso) errors.push('Effective From must be YYYY-MM-DD')
+  if (!Number.isFinite(yieldQty) || yieldQty <= 0) errors.push('Yield Qty must be > 0')
+  if (!yieldUnit) errors.push('Missing Yield Unit')
+  if (!ingredientName) errors.push('Missing Ingredient Name')
+  if (!Number.isFinite(ingredientQty) || ingredientQty <= 0) errors.push('Ingredient Qty must be > 0')
+  if (!ingredientUnit) errors.push('Missing Ingredient Unit')
+  if (!Number.isFinite(lossPct) || lossPct < 0 || lossPct > 100) errors.push('Loss % must be between 0 and 100')
+
+  if (errors.length > 0) {
+    return { ok: false as const, errors, rowNumber }
+  }
+
+  const normalizedProductCode = productCode.toUpperCase()
+  if (!/^[A-Z0-9][A-Z0-9_]{0,63}$/.test(normalizedProductCode)) {
+    return { ok: false as const, errors: ['Product Code must match ^[A-Z0-9][A-Z0-9_]{0,63}$'], rowNumber }
+  }
+
+  return {
+    ok: true as const,
+    row: {
+      productCode: normalizedProductCode,
+      effectiveFrom: effectiveFromIso!,
+      yieldQty,
+      yieldUnit,
+      ingredientName,
+      ingredientQty,
+      ingredientUnit,
+      lossPct,
+      recipeNotes,
+      rowNumber,
+    } satisfies RecipeLineRow,
+  }
+}
+
+function groupRows(rows: RecipeLineRow[]) {
+  const byKey = new Map<RecipeHeaderKey, RecipeHeader>()
+  const errors: string[] = []
+
+  for (const row of rows) {
+    const key = `${row.productCode}__${row.effectiveFrom}` as RecipeHeaderKey
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, {
+        key,
+        productCode: row.productCode,
+        effectiveFromIso: row.effectiveFrom,
+        yieldQty: row.yieldQty,
+        yieldUnit: row.yieldUnit,
+        recipeNotes: row.recipeNotes,
+        lines: [{
+          ingredientName: row.ingredientName,
+          ingredientQty: row.ingredientQty,
+          ingredientUnit: row.ingredientUnit,
+          lossPct: row.lossPct,
+          rowNumber: row.rowNumber,
+        }],
+      })
+      continue
+    }
+
+    if (existing.yieldQty !== row.yieldQty) {
+      errors.push(`Row ${row.rowNumber}: Yield Qty differs within ${row.productCode} @ ${row.effectiveFrom}`)
+    }
+    if (existing.yieldUnit !== row.yieldUnit) {
+      errors.push(`Row ${row.rowNumber}: Yield Unit differs within ${row.productCode} @ ${row.effectiveFrom}`)
+    }
+    const existingNotes = existing.recipeNotes ?? ''
+    const rowNotes = row.recipeNotes ?? ''
+    if (existingNotes && rowNotes && existingNotes !== rowNotes) {
+      errors.push(`Row ${row.rowNumber}: Recipe Notes differs within ${row.productCode} @ ${row.effectiveFrom}`)
+    }
+    if (!existing.recipeNotes && row.recipeNotes) {
+      existing.recipeNotes = row.recipeNotes
+    }
+
+    existing.lines.push({
+      ingredientName: row.ingredientName,
+      ingredientQty: row.ingredientQty,
+      ingredientUnit: row.ingredientUnit,
+      lossPct: row.lossPct,
+      rowNumber: row.rowNumber,
+    })
+  }
+
+  for (const header of byKey.values()) {
+    const seen = new Map<string, number>()
+    for (const line of header.lines) {
+      const k = line.ingredientName.toLowerCase()
+      if (seen.has(k)) {
+        errors.push(`Row ${line.rowNumber}: Duplicate Ingredient Name "${line.ingredientName}" for ${header.productCode} @ ${header.effectiveFromIso.slice(0, 10)}`)
+      } else {
+        seen.set(k, line.rowNumber)
+      }
+    }
+  }
+
+  return { headers: Array.from(byKey.values()), errors }
+}
+
+function loadEnv(envPath: string) {
+  dotenv.config({ path: envPath })
+}
+
+function getSupabaseUrl() {
+  return process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+}
+
+function getSupabaseServiceKey() {
+  return process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+}
+
+function createSupabase(): SupabaseClient {
+  const url = getSupabaseUrl()
+  const key = getSupabaseServiceKey()
+  if (!url || !key) {
+    throw new Error('Missing SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) and SUPABASE_SECRET_KEY (or SUPABASE_SERVICE_ROLE_KEY)')
+  }
+  return createClient(url, key, { auth: { persistSession: false } })
+}
+
+async function fetchCsv(csvUrl: string) {
+  const res = await fetch(csvUrl, { method: 'GET' })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Failed to fetch CSV: ${res.status} ${text}`)
+  }
+  const contentType = res.headers.get('content-type') || ''
+  const text = await res.text()
+  const looksLikeHtml = /^\s*</.test(text) && /<html[\s>]/i.test(text)
+  if (contentType.includes('text/html') || looksLikeHtml) {
+    throw new Error('The provided URL returned HTML, not CSV. Use a Google Sheets CSV export/published CSV URL.')
+  }
+  return text
+}
+
+async function main() {
+  const options = parseArgs(process.argv)
+  loadEnv(options.envPath)
+
+  let csvText = ''
+  if (options.csvPath) {
+    csvText = fs.readFileSync(options.csvPath, 'utf8')
+  } else {
+    const csvUrl = options.csvUrl || process.env.COGS_RECIPES_SHEET_CSV_URL || ''
+    if (!csvUrl) {
+      console.error('Missing COGS_RECIPES_SHEET_CSV_URL (or pass --csv-url / --csv-path)')
+      process.exit(1)
+    }
+    csvText = await fetchCsv(csvUrl)
+  }
+
+  const parsedCsv = parseCsv(csvText)
+  const rawRows = parsedCsv.rows
+  if (rawRows.length === 0) {
+    console.log('No rows found in CSV.')
+    process.exit(0)
+  }
+
+  const requiredHeaders = [
+    'product code',
+    'effective from',
+    'yield qty',
+    'yield unit',
+    'ingredient name',
+    'ingredient qty',
+    'ingredient unit',
+    'loss %',
+  ]
+  const missingHeaders = requiredHeaders.filter(h => !parsedCsv.headers.includes(h))
+  if (missingHeaders.length > 0) {
+    console.error('CSV is missing required headers:')
+    for (const h of missingHeaders) console.error(`- ${h}`)
+    console.error(`Found headers: ${parsedCsv.headers.join(', ') || '(none)'}`)
+    process.exit(1)
+  }
+
+  const parsed: RecipeLineRow[] = []
+  const rowErrors: string[] = []
+
+  for (let i = 0; i < rawRows.length; i += 1) {
+    const rowNumber = i + 2
+    const result = toRecipeLineRow(rawRows[i], rowNumber)
+    if (!result.ok) {
+      rowErrors.push(`Row ${rowNumber}: ${result.errors.join('; ')}`)
+      continue
+    }
+    parsed.push(result.row)
+  }
+
+  const grouped = groupRows(parsed)
+  const allErrors = [...rowErrors, ...grouped.errors]
+  if (allErrors.length > 0) {
+    console.error('Validation errors:')
+    for (const err of allErrors) console.error(`- ${err}`)
+    process.exit(1)
+  }
+
+  const supabase = createSupabase()
+
+  const productCodes = Array.from(new Set(grouped.headers.map(h => h.productCode)))
+  const { data: products, error: productsError } = await supabase
+    .from('cogs_products')
+    .select('id, product_code, name, is_active')
+    .in('product_code', productCodes)
+
+  if (productsError) throw new Error(`Failed loading cogs_products: ${productsError.message}`)
+
+  const productIdByCode = new Map<string, string>()
+  const missingProductCodes: string[] = []
+  for (const code of productCodes) {
+    const match = (products ?? []).find(p => p.product_code === code)
+    if (!match) missingProductCodes.push(code)
+    else productIdByCode.set(code, match.id)
+  }
+  if (missingProductCodes.length > 0) {
+    console.error('Missing product_code in cogs_products:')
+    for (const code of missingProductCodes) console.error(`- ${code}`)
+    process.exit(1)
+  }
+
+  const ingredientNames = Array.from(new Set(grouped.headers.flatMap(h => h.lines.map(l => l.ingredientName))))
+  const { data: inventoryItems, error: inventoryError } = await supabase
+    .from('inventory_items')
+    .select('id, item_name, deleted_at')
+    .in('item_name', ingredientNames)
+
+  if (inventoryError) throw new Error(`Failed loading inventory_items: ${inventoryError.message}`)
+
+  const inventoryIdByName = new Map<string, string>()
+  const missingIngredients: string[] = []
+  for (const name of ingredientNames) {
+    const match = (inventoryItems ?? []).find(i => i.item_name === name)
+    if (!match) missingIngredients.push(name)
+    else inventoryIdByName.set(name, match.id)
+  }
+  if (missingIngredients.length > 0) {
+    console.error('Missing inventory_items.item_name:')
+    for (const name of missingIngredients) console.error(`- ${name}`)
+    process.exit(1)
+  }
+
+  console.log(`${options.dryRun ? 'Dry run' : 'Apply'}: ${grouped.headers.length} recipe headers`)
+
+  let createdRecipes = 0
+  let updatedRecipes = 0
+  let replacedLines = 0
+
+  for (const header of grouped.headers) {
+    const productId = productIdByCode.get(header.productCode)!
+    const effectiveFromIso = header.effectiveFromIso
+
+    const { data: existingRecipes, error: existingError } = await supabase
+      .from('cogs_product_recipes')
+      .select('id, product_id, effective_from')
+      .eq('product_id', productId)
+      .eq('effective_from', effectiveFromIso)
+
+    if (existingError) throw new Error(`Failed loading existing recipes: ${existingError.message}`)
+    if ((existingRecipes ?? []).length > 1) {
+      throw new Error(`Multiple recipes found for ${header.productCode} @ ${effectiveFromIso}`)
+    }
+
+    const newLines = header.lines.map(l => ({
+      inventory_item_id: inventoryIdByName.get(l.ingredientName)!,
+      qty: l.ingredientQty,
+      unit: l.ingredientUnit,
+      loss_pct: l.lossPct,
+    }))
+
+    if (options.dryRun) {
+      const action = (existingRecipes ?? []).length === 0 ? 'CREATE' : 'UPDATE'
+      console.log(`- ${action} ${header.productCode} @ ${effectiveFromIso.slice(0, 10)} (${newLines.length} lines)`)
+      continue
+    }
+
+    const existing = (existingRecipes ?? [])[0] as { id: string } | undefined
+    let recipeId = existing?.id ?? null
+
+    if (!recipeId) {
+      const { data: inserted, error: insertError } = await supabase
+        .from('cogs_product_recipes')
+        .insert([{
+          product_id: productId,
+          version: 1,
+          effective_from: effectiveFromIso,
+          effective_to: null,
+          yield_qty: header.yieldQty,
+          yield_unit: header.yieldUnit,
+          notes: header.recipeNotes,
+        }])
+        .select('id')
+        .single()
+
+      if (insertError || !inserted) throw new Error(`Failed creating recipe for ${header.productCode}: ${insertError?.message ?? 'Unknown error'}`)
+      recipeId = inserted.id
+      createdRecipes += 1
+    } else {
+      const { error: updateError } = await supabase
+        .from('cogs_product_recipes')
+        .update({
+          yield_qty: header.yieldQty,
+          yield_unit: header.yieldUnit,
+          notes: header.recipeNotes,
+        })
+        .eq('id', recipeId)
+
+      if (updateError) throw new Error(`Failed updating recipe for ${header.productCode}: ${updateError.message}`)
+      updatedRecipes += 1
+    }
+
+    const { error: deleteError } = await supabase
+      .from('cogs_product_recipe_lines')
+      .delete()
+      .eq('recipe_id', recipeId)
+
+    if (deleteError) throw new Error(`Failed deleting existing lines for ${header.productCode}: ${deleteError.message}`)
+
+    const { error: insertLinesError } = await supabase
+      .from('cogs_product_recipe_lines')
+      .insert(newLines.map(l => ({ recipe_id: recipeId, ...l })))
+
+    if (insertLinesError) throw new Error(`Failed inserting lines for ${header.productCode}: ${insertLinesError.message}`)
+
+    replacedLines += newLines.length
+  }
+
+  if (!options.dryRun) {
+    console.log(`Done. Created recipes: ${createdRecipes}, updated recipes: ${updatedRecipes}, inserted lines: ${replacedLines}`)
+  }
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/api/admin/cogs/catalog/sync-square/route.ts
+++ b/src/app/api/admin/cogs/catalog/sync-square/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAdminAuth, isAdminAuthSuccess } from '@/lib/admin/middleware'
+import { createServiceClient } from '@/lib/supabase/server'
+import { searchCatalogItems } from '@/lib/square/fetch-client'
+
+type SquareCatalogObject = {
+  type?: string
+  id?: string
+  is_deleted?: boolean
+  item_data?: {
+    name?: string
+    category_id?: string
+    product_type?: string
+    variations?: Array<{
+      type?: string
+      id?: string
+      is_deleted?: boolean
+      item_variation_data?: {
+        name?: string
+      }
+    }>
+  }
+  category_data?: {
+    name?: string
+  }
+}
+
+async function fetchAllSquareCatalogObjects(objectTypes: string[]) {
+  const objects: SquareCatalogObject[] = []
+  let cursor: string | undefined
+  let pages = 0
+
+  while (pages < 25) {
+    pages += 1
+    const payload = (await searchCatalogItems({
+      object_types: objectTypes,
+      cursor,
+      limit: 1000,
+    })) as { objects?: unknown[]; cursor?: unknown }
+
+    const batch = Array.isArray(payload.objects) ? (payload.objects as SquareCatalogObject[]) : []
+    objects.push(...batch)
+
+    cursor = typeof payload.cursor === 'string' ? payload.cursor : undefined
+    if (!cursor) break
+  }
+
+  return objects
+}
+
+function buildSellableName(itemName: string, variationName: string) {
+  const normalizedItem = itemName.trim()
+  const normalizedVariation = variationName.trim()
+  if (!normalizedItem) return normalizedVariation
+  if (!normalizedVariation || normalizedVariation === 'Regular' || normalizedVariation === normalizedItem) return normalizedItem
+  return `${normalizedItem} - ${normalizedVariation}`
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = await requireAdminAuth(request)
+  if (!isAdminAuthSuccess(authResult)) return authResult
+
+  if (!process.env.SQUARE_ACCESS_TOKEN) {
+    return NextResponse.json({ error: 'Missing SQUARE_ACCESS_TOKEN; Square sync is not configured.' }, { status: 500 })
+  }
+  if (!process.env.SQUARE_LOCATION_ID) {
+    return NextResponse.json({ error: 'Missing SQUARE_LOCATION_ID; Square sync is not configured.' }, { status: 500 })
+  }
+
+  try {
+    const objects = await fetchAllSquareCatalogObjects(['ITEM', 'CATEGORY'])
+
+    const categoryNameById = new Map<string, string>()
+    for (const obj of objects) {
+      if (obj.type !== 'CATEGORY') continue
+      if (typeof obj.id !== 'string') continue
+      const name = typeof obj.category_data?.name === 'string' ? obj.category_data.name.trim() : ''
+      if (!name) continue
+      categoryNameById.set(obj.id, name)
+    }
+
+    const productsToUpsert: Array<{ square_item_id: string; name: string; category: string | null; is_active: boolean }> = []
+    const variationsToUpsert: Array<{ square_variation_id: string; square_item_id: string; name: string; is_active: boolean }> = []
+
+    for (const obj of objects) {
+      if (obj.type !== 'ITEM') continue
+      if (typeof obj.id !== 'string') continue
+      const itemName = typeof obj.item_data?.name === 'string' ? obj.item_data.name.trim() : ''
+      if (!itemName) continue
+
+      const productType = typeof obj.item_data?.product_type === 'string' ? obj.item_data.product_type : null
+      if (productType && productType !== 'REGULAR') continue
+
+      const categoryId = typeof obj.item_data?.category_id === 'string' ? obj.item_data.category_id : null
+      const categoryName = categoryId ? (categoryNameById.get(categoryId) ?? null) : null
+      const isActive = obj.is_deleted !== true
+
+      productsToUpsert.push({
+        square_item_id: obj.id,
+        name: itemName,
+        category: categoryName,
+        is_active: isActive,
+      })
+
+      const variations = Array.isArray(obj.item_data?.variations) ? obj.item_data?.variations : []
+      for (const variation of variations) {
+        if (variation?.type !== 'ITEM_VARIATION') continue
+        if (typeof variation.id !== 'string') continue
+        const variationName = typeof variation.item_variation_data?.name === 'string' ? variation.item_variation_data.name : ''
+        const sellableName = buildSellableName(itemName, variationName)
+        if (!sellableName) continue
+        variationsToUpsert.push({
+          square_variation_id: variation.id,
+          square_item_id: obj.id,
+          name: sellableName,
+          is_active: variation.is_deleted !== true,
+        })
+      }
+    }
+
+    const supabase = createServiceClient()
+
+    if (productsToUpsert.length > 0) {
+      const { error } = await supabase
+        .from('cogs_products')
+        .upsert(productsToUpsert, { onConflict: 'square_item_id' })
+
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    const squareItemIds = Array.from(new Set(productsToUpsert.map(p => p.square_item_id)))
+    const { data: productRows, error: productMapError } = squareItemIds.length === 0
+      ? { data: [], error: null as null | { message: string } }
+      : await supabase
+        .from('cogs_products')
+        .select('id,square_item_id')
+        .in('square_item_id', squareItemIds)
+
+    if (productMapError) return NextResponse.json({ error: productMapError.message }, { status: 500 })
+
+    const productIdBySquareItemId = new Map<string, string>()
+    for (const row of productRows ?? []) {
+      if (!row || typeof row !== 'object') continue
+      const r = row as { id?: unknown; square_item_id?: unknown }
+      if (typeof r.id !== 'string' || typeof r.square_item_id !== 'string') continue
+      productIdBySquareItemId.set(r.square_item_id, r.id)
+    }
+
+    const sellablesToUpsert = variationsToUpsert
+      .map(v => {
+        const productId = productIdBySquareItemId.get(v.square_item_id)
+        if (!productId) return null
+        return {
+          square_variation_id: v.square_variation_id,
+          product_id: productId,
+          name: v.name,
+          is_active: v.is_active,
+        }
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null)
+
+    if (sellablesToUpsert.length > 0) {
+      const { error } = await supabase
+        .from('cogs_sellables')
+        .upsert(sellablesToUpsert, { onConflict: 'square_variation_id' })
+
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      ok: true,
+      productsUpserted: productsToUpsert.length,
+      sellablesUpserted: sellablesToUpsert.length,
+    })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to sync from Square' },
+      { status: 500 }
+    )
+  }
+}
+

--- a/src/app/api/admin/cogs/products/[id]/route.ts
+++ b/src/app/api/admin/cogs/products/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/server'
+import { requireAdminAuth, isAdminAuthSuccess } from '@/lib/admin/middleware'
+
+function normalizeText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeProductCode(value: unknown) {
+  const raw = normalizeText(value)
+  if (!raw) return null
+  const normalized = raw.toUpperCase()
+  if (!/^[A-Z0-9][A-Z0-9_]{0,63}$/.test(normalized)) {
+    return { error: 'product_code must match ^[A-Z0-9][A-Z0-9_]{0,63}$ (uppercase letters, numbers, underscore)' }
+  }
+  return normalized
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const authResult = await requireAdminAuth(request)
+  if (!isAdminAuthSuccess(authResult)) return authResult
+
+  const { id } = await params
+  const productId = normalizeText(id)
+  if (!productId) return NextResponse.json({ error: 'Missing product id' }, { status: 400 })
+
+  const body = (await request.json().catch(() => ({}))) as { product_code?: unknown }
+  const normalized = normalizeProductCode(body.product_code)
+  if (normalized && typeof normalized === 'object' && 'error' in normalized) {
+    return NextResponse.json({ error: normalized.error }, { status: 400 })
+  }
+
+  const supabase = createServiceClient()
+  const { data, error } = await supabase
+    .from('cogs_products')
+    .update({ product_code: normalized })
+    .eq('id', productId)
+    .select('id, square_item_id, name, category, is_active, product_code, created_at, updated_at')
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message ?? 'Failed to update product' }, { status: 500 })
+  }
+
+  return NextResponse.json({ product: data })
+}

--- a/src/app/api/admin/cogs/products/route.ts
+++ b/src/app/api/admin/cogs/products/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   const supabase = createServiceClient()
   let query = supabase
     .from('cogs_products')
-    .select('id, square_item_id, name, category, is_active, created_at, updated_at')
+    .select('id, square_item_id, name, category, is_active, product_code, created_at, updated_at')
     .order('name', { ascending: true })
 
   if (!includeInactive) {
@@ -67,4 +67,3 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ product: data })
 }
-

--- a/supabase/migrations/20251217190000_add_product_code_to_cogs_products.sql
+++ b/supabase/migrations/20251217190000_add_product_code_to_cogs_products.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE public.cogs_products
+  ADD COLUMN IF NOT EXISTS product_code text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cogs_products_product_code_unique
+  ON public.cogs_products (lower(product_code))
+  WHERE product_code IS NOT NULL;
+
+COMMENT ON COLUMN public.cogs_products.product_code IS 'Stable human-friendly code used to reference products in recipe imports (e.g., LATTE_12OZ)';
+
+COMMIT;
+


### PR DESCRIPTION
- Add Square→DB catalog sync endpoint + UI button to populate cogs_products/cogs_sellables
- Add cogs_products.product_code (unique, case-insensitive) migration
- Add admin API + UI to edit/save product_code per product
- Add Google Sheets CSV recipe importer that replaces recipe lines to match the sheet (plus --csv-path + better CSV/HTML detection)
- Add documentation for sheet format + importer usage