### PR TITLE
cogs: fix Square catalog sync for production

### DIFF
--- a/src/lib/square/fetch-client.ts
+++ b/src/lib/square/fetch-client.ts
@@ -24,11 +24,14 @@ function getLocationId() {
 }
 
 // Catalog API
-export async function listCatalogObjects(types?: string[]) {
+export async function listCatalogObjects(types?: string[], cursor?: string) {
   try {
     const url = new URL(`${SQUARE_BASE_URL}/v2/catalog/list`)
     if (types) {
       url.searchParams.append('types', types.join(','))
+    }
+    if (cursor) {
+      url.searchParams.append('cursor', cursor)
     }
 
     const response = await fetch(url.toString(), {


### PR DESCRIPTION
- Accept Square ITEM product_type=FOOD_AND_BEV (prod) in addition to REGULAR
- Fetch ITEM_VARIATION objects via /v2/catalog/list and map sellables via item_variation_data.item_id
- Add ?dryRun=1 mode with debug counters (items/types/variation mapping) to diagnose empty syncs
- Add cursor support to listCatalogObjects